### PR TITLE
Pin protobuf to 3.19.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
     python_requires=">=3.7",
     setup_requires=['setuptools_scm>=4,<6.1'],
     install_requires=[
-        'protobuf'
+        'protobuf==3.19.4'
     ]
 )


### PR DESCRIPTION
Currently, we use the latest protobuf. Unfortunately v4 cannot read our protobuf files which were genered with v3. All our other tools such as gftools use 3.19.4 hence why I'm pinning to this version. If I install gflanguages in a new repo I get:

```PYTHON
Traceback (most recent call last):
  File "/Users/marcfoley/Type/font-browser-tests-action/test.py", line 8, in <module>
    from diffenator import run_proofing_tools, run_diffing_tools
  File "/Users/marcfoley/Type/font-browser-tests-action/venv/lib/python3.10/site-packages/diffenator/__init__.py", line 20, in <module>
    from diffenator.screenshot import screenshot_dir
  File "/Users/marcfoley/Type/font-browser-tests-action/venv/lib/python3.10/site-packages/diffenator/screenshot.py", line 6, in <module>
    from diffenator.utils import gen_gifs
  File "/Users/marcfoley/Type/font-browser-tests-action/venv/lib/python3.10/site-packages/diffenator/utils.py", line 22, in <module>
    from gflanguages import LoadLanguages
  File "/Users/marcfoley/Type/font-browser-tests-action/venv/lib/python3.10/site-packages/gflanguages/__init__.py", line 28, in <module>
    from gflanguages import languages_public_pb2
  File "/Users/marcfoley/Type/font-browser-tests-action/venv/lib/python3.10/site-packages/gflanguages/languages_public_pb2.py", line 36, in <module>
    _descriptor.FieldDescriptor(
  File "/Users/marcfoley/Type/font-browser-tests-action/venv/lib/python3.10/site-packages/google/protobuf/descriptor.py", line 560, in __new__
    _message.Message._CheckCalledFromGeneratedFile()
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).

```

I've opted for solution 1 here.