### PR TITLE
Test that all languages have a "script" field which is known to the scripts database

### DIFF
--- a/tests/test_data_languages.py
+++ b/tests/test_data_languages.py
@@ -16,10 +16,11 @@
 #
 import pytest
 from collections import Counter
-from gflanguages import LoadLanguages, languages_public_pb2
+from gflanguages import LoadLanguages, languages_public_pb2, LoadScripts
 
 
 LANGUAGES = LoadLanguages()
+SCRIPTS = LoadScripts()
 
 
 @pytest.mark.parametrize("lang_code", LANGUAGES)
@@ -49,3 +50,9 @@ def test_language_samples(lang_code):
 
     for field in SampleText.fields:
         assert getattr(lang.sample_text, field.name)
+
+
+@pytest.mark.parametrize("lang_code", LANGUAGES.keys())
+def test_script_is_known(lang_code):
+    lang = LANGUAGES[lang_code]
+    assert lang.script in SCRIPTS, f"{lang} used unknown script {lang.script}"

--- a/tests/test_data_languages.py
+++ b/tests/test_data_languages.py
@@ -55,4 +55,5 @@ def test_language_samples(lang_code):
 @pytest.mark.parametrize("lang_code", LANGUAGES.keys())
 def test_script_is_known(lang_code):
     lang = LANGUAGES[lang_code]
-    assert lang.script in SCRIPTS, f"{lang} used unknown script {lang.script}"
+    script = lang.script
+    assert script in SCRIPTS, f"{lang_code} used unknown script {lang.script}"


### PR DESCRIPTION
This test fails because `aii_Chrs` has script `Chrs` which is not in the scripts database.