### PR TITLE
Addition of exemplar character sets for Latin-based African Languages

### DIFF
--- a/Lib/gflanguages/data/languages/abi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/abi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "abi_Latn"
+language: "abi"
+script: "Latn"
+name: "Abidji"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ w W y Y"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/acd_Latn.textproto
+++ b/Lib/gflanguages/data/languages/acd_Latn.textproto
@@ -1,0 +1,8 @@
+id: "acd_Latn"
+language: "acd"
+script: "Latn"
+name: "Gikyode"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U w W y Y ŋ Ŋ ɔ Ɔ ɛ Ɛ ꞌ Ꞌ"
+  auxiliary: "c C j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ade_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ade_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ade_Latn"
+language: "ade"
+script: "Latn"
+name: "Adele"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I ɩ Ɩ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ w W y Y"
+  auxiliary: "c C j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/adj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/adj_Latn.textproto
@@ -1,0 +1,9 @@
+id: "adj_Latn"
+language: "adj"
+script: "Latn"
+name: "Adioukrou"
+exemplar_chars {
+  base: "a A b B c C d D e E ê Ê f F g G h H i I j J k K l L m M n N o O ô Ô p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɛ Ɛ ↄ Ↄ"
+  marks: "◌̂ ◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/aeb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/aeb_Latn.textproto
@@ -1,0 +1,9 @@
+id: "aeb_Latn"
+language: "aeb"
+script: "Latn"
+name: "Tunisian Darija"
+exemplar_chars {
+  base: "a A ā Ā b B c C d D đ Đ e E ē Ē ɛ Ɛ f F g G ɣ Ɣ h H ħ Ħ i I ī Ī j J k K l L m M n N o O p P q Q r R s S ṣ Ṣ t T ṭ Ṭ ŧ Ŧ u U ū Ū v V w W x X y Y z Z"
+  marks: "◌̄ ◌̣ ◌̀"
+  auxiliary: "à À ḅ Ḅ ḍ Ḍ è È ḕ Ḕ ì Ì ḷ Ḷ ṃ Ṃ ò Ò ṛ Ṛ ù Ù ẓ Ẓ"
+}

--- a/Lib/gflanguages/data/languages/agc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/agc_Latn.textproto
@@ -1,0 +1,8 @@
+id: "agc_Latn"
+language: "agc"
+script: "Latn"
+name: "Agatu"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/aha_Latn.textproto
+++ b/Lib/gflanguages/data/languages/aha_Latn.textproto
@@ -1,0 +1,8 @@
+id: "aha_Latn"
+language: "aha"
+script: "Latn"
+name: "Ahanta"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G ɣ Ɣ h H i I ɩ Ɩ k K l L m M n N o O ɔ Ɔ p P s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "c C j J q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/ahl_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ahl_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ahl_Latn"
+language: "ahl"
+script: "Latn"
+name: "Igo"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D ɖ Ɖ e E è È é É ɛ Ɛ f F g G h H i I ì Ì í Í j J k K l L m M n N ŋ Ŋ o O ò Ò ó Ó ɔ Ɔ p P r R s S t T u U ù Ù ú Ú v V w W y Y z Z"
+  marks: "◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ahs_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ahs_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ahs_Latn"
+language: "ahs"
+script: "Latn"
+name: "Ashe"
+exemplar_chars {
+  base: "a A á Á ã Ã b B c C d D e E é É ẽ Ẽ ɛ Ɛ f F g G h H i I í Í j J k K l L m M n N ŋ Ŋ o O ó Ó õ Õ ɔ Ɔ p P r R t T u U ú Ú ũ Ũ v V w W y Y"
+  marks: "◌́ ◌̃ ◌́"
+  auxiliary: "q Q s S x X z Z"
+}

--- a/Lib/gflanguages/data/languages/akp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/akp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "akp_Latn"
+language: "akp"
+script: "Latn"
+name: "Siwu"
+exemplar_chars {
+  base: "a A ã Ã b B d D e E f F g G h H i I ĩ Ĩ k K l L m M n N o O p P r R s S t T u U ũ Ũ v V w W y Y z Z ɔ Ɔ ɖ Ɖ ɛ Ɛ ɣ Ɣ"
+  marks: "◌̃"
+}

--- a/Lib/gflanguages/data/languages/ala_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ala_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ala_Latn"
+language: "ala"
+script: "Latn"
+name: "Alago"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N ñ Ñ o O p P r R s S t T u U w W y Y z Z"
+  marks: "◌̃"
+  auxiliary: "c C q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/anc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/anc_Latn.textproto
@@ -1,0 +1,9 @@
+id: "anc_Latn"
+language: "anc"
+script: "Latn"
+name: "Ngas"
+exemplar_chars {
+  base: "a A à À á Á b B ɓ Ɓ c C d D ɗ Ɗ e E è È é É ə Ə f F g G h H ḥ Ḥ i I ì Ì í Í j J k K ƙ Ƙ l L m M n N ṇ Ṇ o O ò Ò ó Ó p P r R s S t T u U ù Ù ú Ú v V w W y Y z Z ẓ Ẓ"
+  marks: "◌̀ ◌́ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ank_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ank_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ank_Latn"
+language: "ank"
+script: "Latn"
+name: "Goemai"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ann_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ann_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ann_Latn"
+language: "ann"
+script: "Latn"
+name: "Obolo"
+exemplar_chars {
+  base: "a A à À â Â b B c C d D e E è È ê Ê f F g G h H i I ì Ì î Î j J k K l L m M n N ǹ Ǹ o O ò Ò ô Ô ọ Ọ ộ Ộ p P r R s S t T u U ù Ù û Û v V w W"
+  marks: "◌̀ ◌̂ ◌̀ ◌̄ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/anv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/anv_Latn.textproto
@@ -1,0 +1,8 @@
+id: "anv_Latn"
+language: "anv"
+script: "Latn"
+name: "Denya"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y ŋ Ŋ ɔ Ɔ ɛ Ɛ"
+  marks: "◌́"
+}

--- a/Lib/gflanguages/data/languages/any_Latn.textproto
+++ b/Lib/gflanguages/data/languages/any_Latn.textproto
@@ -1,0 +1,9 @@
+id: "any_Latn"
+language: "any"
+script: "Latn"
+name: "Anyin"
+exemplar_chars {
+  base: "a A â Â b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z ɔ Ɔ ɛ Ɛ ɩ Ɩ ʋ Ʋ"
+  marks: "◌̂ ◌́"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/apd_Latn.textproto
+++ b/Lib/gflanguages/data/languages/apd_Latn.textproto
@@ -1,0 +1,9 @@
+id: "apd_Latn"
+language: "apd"
+script: "Latn"
+name: "Sudanese Arabic"
+exemplar_chars {
+  base: "a A b B d D ḍ Ḍ f F g G h H ḥ Ḥ i I j J k K x X l L m M n N r R s S ṣ Ṣ t T ṭ Ṭ u U w W y Y z Z ẓ Ẓ"
+  marks: "◌̣ ◌͟"
+  auxiliary: "c C e E o O p P q Q v V"
+}

--- a/Lib/gflanguages/data/languages/asg_Latn.textproto
+++ b/Lib/gflanguages/data/languages/asg_Latn.textproto
@@ -1,0 +1,8 @@
+id: "asg_Latn"
+language: "asg"
+script: "Latn"
+name: "Cishingini"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+  marks: "◌̱"
+}

--- a/Lib/gflanguages/data/languages/atg_Latn.textproto
+++ b/Lib/gflanguages/data/languages/atg_Latn.textproto
@@ -1,0 +1,9 @@
+id: "atg_Latn"
+language: "atg"
+script: "Latn"
+name: "Ivbie North-Okpela-Arhe"
+exemplar_chars {
+  base: "a A ā Ā b B c C d D e E ẹ Ẹ f F g G h H i I j J k K l L m M n N o O ō Ō ọ Ọ p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̄ ◌̣ ◌̌ ◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/avn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/avn_Latn.textproto
@@ -1,0 +1,8 @@
+id: "avn_Latn"
+language: "avn"
+script: "Latn"
+name: "Avatime"
+exemplar_chars {
+  base: "a A b B d D ɖ Ɖ e E ɛ Ɛ f F ƒ Ƒ g G h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V ʋ Ʋ w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/avu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/avu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "avu_Latn"
+language: "avu"
+script: "Latn"
+name: "Avokaya"
+exemplar_chars {
+  base: "a A ạ Ạ b B c C d D e E f F g G h H ı I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ꞌ Ꞌ"
+  marks: "◌̣ ◌́ ◌̂ ◌̃"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/awo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/awo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "awo_Latn"
+language: "awo"
+script: "Latn"
+name: "Awak"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/ayb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ayb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ayb_Latn"
+language: "ayb"
+script: "Latn"
+name: "Ayizo-Gbe"
+exemplar_chars {
+  base: "a A b B d D ɗ Ɗ e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U v V w W x X z Z"
+  auxiliary: "c C q Q y Y"
+}

--- a/Lib/gflanguages/data/languages/bav_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bav_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bav_Latn"
+language: "bav"
+script: "Latn"
+name: "Vengo"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O s S t T u U ú Ú v V w W y Y z Z ŋ Ŋ ɔ Ɔ ə Ə ɨ Ɨ ꞌ Ꞌ"
+  marks: "◌̰ ◌́ ◌̀"
+  auxiliary: "c C p P q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/bbp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bbp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bbp_Latn"
+language: "bbp"
+script: "Latn"
+name: "Banda, West Central"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "h H"
+}

--- a/Lib/gflanguages/data/languages/bcn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bcn_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bcn_Latn"
+language: "bcn"
+script: "Latn"
+name: "Bali"
+exemplar_chars {
+  base: "á Á a A à À ã Ã b B ɓ Ɓ d D ɗ Ɗ é É e E è È ẽ Ẽ f F g G h H í Í i I ì Ì ĩ Ĩ j J k K l L m M n N ó Ó o O ò Ò ṍ Ṍ õ Õ ɔ Ɔ p P r R s S t T ú Ú u U ù Ù ṹ Ṹ ũ Ũ v V ʋ Ʋ w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̃ ◌́ ◌̀"
+  auxiliary: "c C q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bcq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bcq_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bcq_Latn"
+language: "bcq"
+script: "Latn"
+name: "Bench"
+exemplar_chars {
+  base: "a A b B c C d D e E g G h H i I k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "f F j J"
+}

--- a/Lib/gflanguages/data/languages/bcw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bcw_Latn.textproto
@@ -1,0 +1,7 @@
+id: "bcw_Latn"
+language: "bcw"
+script: "Latn"
+name: "Bana"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N p P r R s S t T v V w W y Y z Z ŋ Ŋ ɓ Ɓ ɗ Ɗ ə Ə ꞌ Ꞌ"
+}

--- a/Lib/gflanguages/data/languages/bcy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bcy_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bcy_Latn"
+language: "bcy"
+script: "Latn"
+name: "Bacama"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ə Ə f F g G h H i I ɨ Ɨ j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ꞌ Ꞌ"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bdh_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bdh_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bdh_Latn"
+language: "bdh"
+script: "Latn"
+name: "Baka"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I ị Ị k K l L m M n N ṇ Ṇ o O p P r R ṛ Ṛ s S t T u U ụ Ụ v V ṿ Ṿ w W y Y z Z ɨ Ɨ ꞌ Ꞌ"
+  marks: "◌̣ ◌́"
+}

--- a/Lib/gflanguages/data/languages/beh_Latn.textproto
+++ b/Lib/gflanguages/data/languages/beh_Latn.textproto
@@ -1,0 +1,8 @@
+id: "beh_Latn"
+language: "beh"
+script: "Latn"
+name: "Baka"
+exemplar_chars {
+  base: "a A b B c C d D e E ə Ə f F g G h H i I k K l L m M n N o O p P r R s S t T u U w W y Y"
+  auxiliary: "j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bej_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bej_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bej_Latn"
+language: "bej"
+script: "Latn"
+name: "Bedawiyet"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O r R s S t T u U w W y Y"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bet_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bet_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bet_Latn"
+language: "bet"
+script: "Latn"
+name: "Bété, Guiberoua"
+exemplar_chars {
+  base: "a A ä Ä b B c C d D e E ë Ë ɛ Ɛ f F g G i I ï Ï ɩ Ɩ j J k K l L m M n N o O ö Ö ɔ Ɔ p P s S t T u U ʋ Ʋ v V w W y Y z Z"
+  marks: "◌̈"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/bex_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bex_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bex_Latn"
+language: "bex"
+script: "Latn"
+name: "Jur Modo"
+exemplar_chars {
+  base: "a A b B c C d D f F e E ë Ë h H g G i I ï Ï j J k K l L m M n N ŋ Ŋ ꞌ Ꞌ o O ö Ö ɔ Ɔ p P r R s S t T u U w W y Y z Z"
+  marks: "◌̈"
+  auxiliary: "f F h H q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/bhy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bhy_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bhy_Latn"
+language: "bhy"
+script: "Latn"
+name: "Bhele"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ g G h H i I j J k K l L m M n N o O ɔ Ɔ p P s S t T u U w W y Y"
+  auxiliary: "c C f F q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bib_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bib_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bib_Latn"
+language: "bib"
+script: "Latn"
+name: "Bisa"
+exemplar_chars {
+  base: "a A b B c C d D e E ə Ə ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z ʊ Ʊ"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bim_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bim_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bim_Latn"
+language: "bim"
+script: "Latn"
+name: "Bimoba"
+exemplar_chars {
+  base: "a A â Â b B c C d D e E ê Ê f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y ŋ Ŋ ɔ Ɔ"
+  marks: "◌̂"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/biv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/biv_Latn.textproto
@@ -1,0 +1,8 @@
+id: "biv_Latn"
+language: "biv"
+script: "Latn"
+name: "Birifor, Southern"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y ŋ Ŋ ɔ Ɔ ɛ Ɛ ɩ Ɩ ʊ Ʊ"
+  marks: "◌̃"
+}

--- a/Lib/gflanguages/data/languages/bjv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bjv_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bjv_Latn"
+language: "bjv"
+script: "Latn"
+name: "Bedjond"
+exemplar_chars {
+  base: "a A b B d D e E é É g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y ɓ Ɓ ɔ Ɔ ə Ə ɨ Ɨ"
+  marks: "◌́ ◌̰"
+}

--- a/Lib/gflanguages/data/languages/bkc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bkc_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bkc_Latn"
+language: "bkc"
+script: "Latn"
+name: "Baka"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ s S t T u U w W y Y"
+  auxiliary: "c C p P q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bkv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bkv_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bkv_Latn"
+language: "bkv"
+script: "Latn"
+name: "Bekwarra"
+exemplar_chars {
+  base: "a A á Á ā Ā à À â Â ǎ Ǎ b B c C d D e E é É ē Ē è È ě Ě f F g G h H i I í Í ī Ī ì Ì î Î j J k K l L ḿ Ḿ m M n N ń Ń ǹ Ǹ o O ó Ó ō Ō ò Ò p P r R s S t T u U ú Ú ū Ū ù Ù û Û w W y Y"
+  marks: "◌́ ◌̄ ◌̀ ◌̂ ◌̌ ◌̀"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/blo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/blo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "blo_Latn"
+language: "blo"
+script: "Latn"
+name: "Anii"
+exemplar_chars {
+  base: "a A ǝ Ǝ b B c C ɖ Ɖ e E ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʊ Ʊ w W y Y"
+  auxiliary: "d D q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bng_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bng_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bng_Latn"
+language: "bng"
+script: "Latn"
+name: "Benga"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y"
+  auxiliary: "c C j J q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bnm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bnm_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bnm_Latn"
+language: "bnm"
+script: "Latn"
+name: "Bapuku"
+exemplar_chars {
+  base: "a A b B d D e E h H i I j J k K l L m M n N ñ Ñ o O p P r R s S t T u U v V w W y Y"
+  marks: "◌̃"
+  auxiliary: "f F g G q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bom_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bom_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bom_Latn"
+language: "bom"
+script: "Latn"
+name: "Berom"
+exemplar_chars {
+  base: "a A à À á Á ã Ã b B c C d D e E è È é É ẹ Ẹ ẽ Ẽ f F g G h H i I ì Ì í Í ĩ Ĩ j J k K l L m M ḿ Ḿ n N ǹ Ǹ ń Ń o O ò Ò ó Ó ọ Ọ õ Õ"
+  marks: "◌̀ ◌́ ◌̃ ◌̣ ◌̄"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bov_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bov_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bov_Latn"
+language: "bov"
+script: "Latn"
+name: "Tuwuli"
+exemplar_chars {
+  base: "a A á Á ã Ã b B d D e E f F g G h H i I í Í ĩ Ĩ k K l L m M n N o O ó Ó p P r R s S t T u U ũ Ũ v V w W y Y z Z ɔ Ɔ ɛ Ɛ"
+  marks: "◌́ ◌̃"
+}

--- a/Lib/gflanguages/data/languages/box_Latn.textproto
+++ b/Lib/gflanguages/data/languages/box_Latn.textproto
@@ -1,0 +1,8 @@
+id: "box_Latn"
+language: "box"
+script: "Latn"
+name: "Buamu"
+exemplar_chars {
+  base: "a A ã Ã b B c C d D e E f F h H i I ĩ Ĩ k K l L m M n N o O p P r R s S t T u U ũ Ũ v V w W y Y z Z ɓ Ɓ ɔ Ɔ ɛ Ɛ ɲ Ɲ"
+  marks: "◌̃ ◌̀ ◌́"
+}

--- a/Lib/gflanguages/data/languages/boz_Latn.textproto
+++ b/Lib/gflanguages/data/languages/boz_Latn.textproto
@@ -1,0 +1,8 @@
+id: "boz_Latn"
+language: "boz"
+script: "Latn"
+name: "Bozo, Tieyaxo"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ɲ Ɲ ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U w W x X y Y"
+  auxiliary: "c C v V z Z"
+}

--- a/Lib/gflanguages/data/languages/bqc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bqc_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bqc_Latn"
+language: "bqc"
+script: "Latn"
+name: "Boko"
+exemplar_chars {
+  base: "a A á Á ã Ã b B d D e E è È ɛ Ɛ f F g G i I í Í ĩ Ĩ k K l L m M n N o O ó Ó ɔ Ɔ p P s S t T u U ú Ú ũ Ũ ṹ Ṹ v V w W y Y z Z"
+  marks: "◌́ ◌̃ ◌̀"
+  auxiliary: "c C h H j J q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/bqj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bqj_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bqj_Latn"
+language: "bqj"
+script: "Latn"
+name: "Bandial"
+exemplar_chars {
+  base: "a A á Á b B c C ĉ Ĉ d D e E é É f F g G h H i I í Í j J k K l L m M n N ñ Ñ o O ó Ó p P r R s S t T u U ú Ú v V w W y Y ŋ Ŋ ᵽ Ᵽ"
+  marks: "◌́ ◌̂ ◌̃"
+}

--- a/Lib/gflanguages/data/languages/bqp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bqp_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bqp_Latn"
+language: "bqp"
+script: "Latn"
+name: "Bisã"
+exemplar_chars {
+  base: "a A á Á à À ã Ã b B c C d D e E é É è È ɛ Ɛ f F g G h H i I í Í ì Ì ĩ Ĩ j J k K l L m M ḿ Ḿ n N ń Ń ǹ Ǹ o O ó Ó ò Ò ɔ Ɔ p P r R s S t T u U ú Ú ù Ù ũ Ũ v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̃ ◌̃ ◌̀"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bsj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bsj_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bsj_Latn"
+language: "bsj"
+script: "Latn"
+name: "Bangwinji"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bsp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bsp_Latn.textproto
@@ -1,0 +1,7 @@
+id: "bsp_Latn"
+language: "bsp"
+script: "Latn"
+name: "Baga Sitemu"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y ŋ Ŋ ɔ Ɔ ə Ə ɛ Ɛ"
+}

--- a/Lib/gflanguages/data/languages/bsq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bsq_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bsq_Latn"
+language: "bsq"
+script: "Latn"
+name: "Bassa"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ č Č d D ɖ Ɖ e E ɛ Ɛ f F g G h H i I j J k K m M n N o O ɔ Ɔ p P s S t T u U v V w W"
+  marks: "◌̌"
+  auxiliary: "l L q Q r R x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/btt_Latn.textproto
+++ b/Lib/gflanguages/data/languages/btt_Latn.textproto
@@ -1,0 +1,9 @@
+id: "btt_Latn"
+language: "btt"
+script: "Latn"
+name: "Bete-Bendi"
+exemplar_chars {
+  base: "a A á Á ā Ā à À ǎ Ǎ â Â b B c C d D e E é É ē Ē è È ě Ě ê Ê f F g G h H i I í Í ī Ī ì Ì ǐ Ǐ î Î j J k K l L m M n N o O ó Ó ō Ō ò Ò ǒ Ǒ ô Ô p P r R s S t T u U ú Ú ū Ū ù Ù ǔ Ǔ û Û v V w W y Y z Z"
+  marks: "◌́ ◌̄ ◌̀ ◌̌ ◌̂ ◌᷅ ◌᷆"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bud_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bud_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bud_Latn"
+language: "bud"
+script: "Latn"
+name: "Ntcham"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D e E è È é É f F g G i I ì Ì í Í j J k K l L ĺ Ĺ m M ḿ Ḿ n N ǹ Ǹ ń Ń ŋ Ŋ o O ò Ò ó Ó ɔ Ɔ p P s S t T u U ù Ù ú Ú w W y Y ÿ Ÿ"
+  marks: "◌̀ ◌́ ◌̈"
+  auxiliary: "h H q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bus_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bus_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bus_Latn"
+language: "bus"
+script: "Latn"
+name: "Bokobaru"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/buu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/buu_Latn.textproto
@@ -1,0 +1,8 @@
+id: "buu_Latn"
+language: "buu"
+script: "Latn"
+name: "Budu"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I ɨ Ɨ j J k K l L m M n N o O ɔ Ɔ p P s S t T u U ʉ Ʉ v V w W y Y z Z"
+  auxiliary: "c C q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/bwr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bwr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bwr_Latn"
+language: "bwr"
+script: "Latn"
+name: "Bura-Pabir"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ə Ə f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/byn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/byn_Latn.textproto
@@ -1,0 +1,9 @@
+id: "byn_Latn"
+language: "byn"
+script: "Latn"
+name: "Bilen"
+exemplar_chars {
+  base: "a A b B c C d D e E é É f F g G h H i I j J k K l L m M n N ñ Ñ o O q Q r R s S t T u U w W x X y Y"
+  marks: "◌́ ◌̃"
+  auxiliary: "p P v V z Z"
+}

--- a/Lib/gflanguages/data/languages/bys_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bys_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bys_Latn"
+language: "bys"
+script: "Latn"
+name: "Burak"
+exemplar_chars {
+  base: "a A á Á à À b B ɓ Ɓ c C d D ɗ Ɗ e E é É è È f F g G h H i I j J k K l L m M n N o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/bza_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bza_Latn.textproto
@@ -1,0 +1,8 @@
+id: "bza_Latn"
+language: "bza"
+script: "Latn"
+name: "Bandi"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G ɣ Ɣ h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U v V w W y Y"
+  auxiliary: "c C j J q Q r R x X z Z"
+}

--- a/Lib/gflanguages/data/languages/bzw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/bzw_Latn.textproto
@@ -1,0 +1,9 @@
+id: "bzw_Latn"
+language: "bzw"
+script: "Latn"
+name: "Basa"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U ụ Ụ v V w W y Y z Z"
+  marks: "◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/cbj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cbj_Latn.textproto
@@ -1,0 +1,9 @@
+id: "cbj_Latn"
+language: "cbj"
+script: "Latn"
+name: "Ede Cabe"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y"
+  marks: "◌́ ◌̀"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/cdr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cdr_Latn.textproto
@@ -1,0 +1,9 @@
+id: "cdr_Latn"
+language: "cdr"
+script: "Latn"
+name: "Kamuku"
+exemplar_chars {
+  base: "â Â a A á Á b B c C d D e E é É g G h H i I í Í j J k K l L m M n N o O ó Ó ô Ô p P r R s S t T u U ú Ú û Û w W x X y Y z Z ꞌ Ꞌ"
+  marks: "◌̂ ◌́ ◌̱ ◌̂"
+  auxiliary: "f F"
+}

--- a/Lib/gflanguages/data/languages/cfa_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cfa_Latn.textproto
@@ -1,0 +1,8 @@
+id: "cfa_Latn"
+language: "cfa"
+script: "Latn"
+name: "Dikaka"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ckl_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ckl_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ckl_Latn"
+language: "ckl"
+script: "Latn"
+name: "Kibaku"
+exemplar_chars {
+  base: "a A ā Ā ă Ă á Á b B ɓ Ɓ c C d D ɗ Ɗ e E ɛ Ɛ ǝ Ǝ f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P r R s S t T u U ū Ū v V w W y Y z Z"
+  marks: "◌̄ ◌̆ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/cko_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cko_Latn.textproto
@@ -1,0 +1,9 @@
+id: "cko_Latn"
+language: "cko"
+script: "Latn"
+name: "Anufo"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/cky_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cky_Latn.textproto
@@ -1,0 +1,9 @@
+id: "cky_Latn"
+language: "cky"
+script: "Latn"
+name: "Cakfem-Mushere"
+exemplar_chars {
+  base: "a A à À á Á b B ɓ Ɓ c C d D ɗ Ɗ e E è È é É f F g G h H i I ì Ì í Í ɨ Ɨ j J k K l L m M n N o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/cla_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cla_Latn.textproto
@@ -1,0 +1,8 @@
+id: "cla_Latn"
+language: "cla"
+script: "Latn"
+name: "Ron"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/cme_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cme_Latn.textproto
@@ -1,0 +1,9 @@
+id: "cme_Latn"
+language: "cme"
+script: "Latn"
+name: "Cerma"
+exemplar_chars {
+  base: "a A ã Ã b B c C d D e E f F g G h H i I ĩ Ĩ j J k K l L m M n N o O p P r R s S t T u U ũ Ũ v V w W y Y ŋ Ŋ ɔ Ɔ ɛ Ɛ"
+  marks: "◌̃"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/csk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/csk_Latn.textproto
@@ -1,0 +1,8 @@
+id: "csk_Latn"
+language: "csk"
+script: "Latn"
+name: "Jola-Kasa"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É f F g G h H i I í Í j J k K l L m M n N ñ Ñ o O ó Ó s S t T u U ú Ú w W y Y ŋ Ŋ"
+  marks: "◌́ ◌̥ ◌̃"
+}

--- a/Lib/gflanguages/data/languages/cwe_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cwe_Latn.textproto
@@ -1,0 +1,7 @@
+id: "cwe_Latn"
+language: "cwe"
+script: "Latn"
+name: "Kwere"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/daa_Latn.textproto
+++ b/Lib/gflanguages/data/languages/daa_Latn.textproto
@@ -1,0 +1,8 @@
+id: "daa_Latn"
+language: "daa"
+script: "Latn"
+name: "Dangaléat"
+exemplar_chars {
+  base: "a A b B c C d D e E g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y z Z ŋ Ŋ ƴ Ƴ ɓ Ɓ ɗ Ɗ"
+  marks: "◌̰"
+}

--- a/Lib/gflanguages/data/languages/dbd_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dbd_Latn.textproto
@@ -1,0 +1,9 @@
+id: "dbd_Latn"
+language: "dbd"
+script: "Latn"
+name: "Dadiya"
+exemplar_chars {
+  base: "a A á Á ǝ Ǝ b B c C d D e E é É ɛ Ɛ f F g G h H i I í Í ɨ Ɨ j J k K l L m M n N ń Ń o O ó Ó ɔ Ɔ p P r R s S t T u U ú Ú ʊ Ʊ v V w W y Y z Z"
+  marks: "◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/dbq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dbq_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dbq_Latn"
+language: "dbq"
+script: "Latn"
+name: "Daba"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ ə Ə e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/dgh_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dgh_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dgh_Latn"
+language: "dgh"
+script: "Latn"
+name: "Dghwede"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/dgi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dgi_Latn.textproto
@@ -1,0 +1,9 @@
+id: "dgi_Latn"
+language: "dgi"
+script: "Latn"
+name: "Dagara, Northern"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D e E ɛ Ɛ f F g G h H ɦ Ɦ i I ɩ Ɩ j J k K l L m M n N ñ Ñ ŋ Ŋ o O ɔ Ɔ p P r R ɾ ɾ s S t T u U ʋ Ʋ v V w W y Y ƴ Ƴ z Z"
+  marks: "◌̃"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/did_Latn.textproto
+++ b/Lib/gflanguages/data/languages/did_Latn.textproto
@@ -1,0 +1,8 @@
+id: "did_Latn"
+language: "did"
+script: "Latn"
+name: "Didinga"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E ẽ Ẽ g G h H i I ĩ Ĩ j J k K l L m M n N o O õ Õ p P r R s S t T u U ú Ú ũ Ũ v V w W y Y ꞌ Ꞌ"
+  marks: "◌́ ◌̃"
+}

--- a/Lib/gflanguages/data/languages/dop_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dop_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dop_Latn"
+language: "dop"
+script: "Latn"
+name: "Lukpa"
+exemplar_chars {
+  base: "a A c C e E ɛ Ɛ ǝ Ǝ f F h H i I ɩ Ɩ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P ɣ Ɣ s S t T u U ʊ Ʊ w W y Y"
+  auxiliary: "b B d D g G j J q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/dow_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dow_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dow_Latn"
+language: "dow"
+script: "Latn"
+name: "Doyayo"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ ɛ Ɛ e E f F g G h H i I k K l L m M n N ŋ Ŋ ɔ Ɔ o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/dri_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dri_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dri_Latn"
+language: "dri"
+script: "Latn"
+name: "C’Lela"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/dts_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dts_Latn.textproto
@@ -1,0 +1,9 @@
+id: "dts_Latn"
+language: "dts"
+script: "Latn"
+name: "Dogon, Toro So"
+exemplar_chars {
+  base: "a A b B c C d D e E è È f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ò Ò p P r R s S t T u U ü Ü w W y Y z Z"
+  marks: "◌̀ ◌̈"
+  auxiliary: "q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/dug_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dug_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dug_Latn"
+language: "dug"
+script: "Latn"
+name: "Chiduruma"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C q Q x X"
+}

--- a/Lib/gflanguages/data/languages/dwr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dwr_Latn.textproto
@@ -1,0 +1,7 @@
+id: "dwr_Latn"
+language: "dwr"
+script: "Latn"
+name: "Dawro"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/dyi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dyi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "dyi_Latn"
+language: "dyi"
+script: "Latn"
+name: "Sénoufo, Djimini"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ɛ Ɛ"
+  marks: "◌̀"
+}

--- a/Lib/gflanguages/data/languages/dzg_Latn.textproto
+++ b/Lib/gflanguages/data/languages/dzg_Latn.textproto
@@ -1,0 +1,9 @@
+id: "dzg_Latn"
+language: "dzg"
+script: "Latn"
+name: "Dazaga"
+exemplar_chars {
+  base: "a A b B c C d D e E ẹ Ẹ ɛ Ɛ ə Ə f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ọ Ọ ɔ Ɔ p P r R s S š Š t T u U w W y Y z Z"
+  marks: "◌̣ ◌̌"
+  auxiliary: "q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/ekm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ekm_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ekm_Latn"
+language: "ekm"
+script: "Latn"
+name: "Elip"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U w W y Y"
+  auxiliary: "j J q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ema_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ema_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ema_Latn"
+language: "ema"
+script: "Latn"
+name: "Emai-Iuleha-Ora"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̠"
+  auxiliary: "c C q Q x X"
+}

--- a/Lib/gflanguages/data/languages/enn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/enn_Latn.textproto
@@ -1,0 +1,9 @@
+id: "enn_Latn"
+language: "enn"
+script: "Latn"
+name: "Engenni"
+exemplar_chars {
+  base: "a A à À b B ɓ Ɓ c C d D ɗ Ɗ e E è È ẹ Ẹ f F g G h H i I ì Ì ị Ị j J k K l L m M n N o O ò Ò ọ Ọ p P r R s S t T u U ù Ù ụ Ụ v V w W y Y z Z"
+  marks: "◌̀ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/etu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/etu_Latn.textproto
@@ -1,0 +1,7 @@
+id: "etu_Latn"
+language: "etu"
+script: "Latn"
+name: "Ejagham"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I ɨ Ɨ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ ø Ø œ Œ p P q Q r R s S t T u U ʉ Ʉ v V w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/etx_Latn.textproto
+++ b/Lib/gflanguages/data/languages/etx_Latn.textproto
@@ -1,0 +1,8 @@
+id: "etx_Latn"
+language: "etx"
+script: "Latn"
+name: "Iten"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+  marks: "◌̱"
+}

--- a/Lib/gflanguages/data/languages/eza_Latn.textproto
+++ b/Lib/gflanguages/data/languages/eza_Latn.textproto
@@ -1,0 +1,8 @@
+id: "eza_Latn"
+language: "eza"
+script: "Latn"
+name: "Ezaa"
+exemplar_chars {
+  base: "a A b B c C d D e E ẹ Ẹ f F g G h H i I ị Ị j J k K l L m M n N o O ọ Ọ p P r R s S t T u U ụ Ụ v V w W y Y z Z"
+  marks: "◌̣ ◌̀ ◌́"
+}

--- a/Lib/gflanguages/data/languages/flr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/flr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "flr_Latn"
+language: "flr"
+script: "Latn"
+name: "Fuliiru"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/fmp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/fmp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "fmp_Latn"
+language: "fmp"
+script: "Latn"
+name: "Fe’fe’"
+exemplar_chars {
+  base: "a A ɑ Ɑ b B c C d D e E ə Ə f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U ʉ Ʉ v V w W y Y z Z"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/fod_Latn.textproto
+++ b/Lib/gflanguages/data/languages/fod_Latn.textproto
@@ -1,0 +1,9 @@
+id: "fod_Latn"
+language: "fod"
+script: "Latn"
+name: "Foodo"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ɛ Ɛ f F g G h H i I í Í ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ó Ó ɔ Ɔ p P s S t T u U ú Ú ʊ Ʊ v V w W y Y z Z"
+  marks: "◌́"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/fub_Latn.textproto
+++ b/Lib/gflanguages/data/languages/fub_Latn.textproto
@@ -1,0 +1,8 @@
+id: "fub_Latn"
+language: "fub"
+script: "Latn"
+name: "Fulfulde, Adamawa"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U w W y Y ƴ Ƴ"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/fue_Latn.textproto
+++ b/Lib/gflanguages/data/languages/fue_Latn.textproto
@@ -1,0 +1,8 @@
+id: "fue_Latn"
+language: "fue"
+script: "Latn"
+name: "Fulfulde, Borgu"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U w W y Y ƴ Ƴ"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/fuh_Latn.textproto
+++ b/Lib/gflanguages/data/languages/fuh_Latn.textproto
@@ -1,0 +1,8 @@
+id: "fuh_Latn"
+language: "fuh"
+script: "Latn"
+name: "Fulfulde, Western Niger"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U w W y Y ƴ Ƴ"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/gby_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gby_Latn.textproto
@@ -1,0 +1,9 @@
+id: "gby_Latn"
+language: "gby"
+script: "Latn"
+name: "Gbari"
+exemplar_chars {
+  base: "á Á a A à À â Â ǎ Ǎ b B ɓ Ɓ d D ɗ Ɗ é É e E è È ê Ê ě Ě f F g G h H í Í i I ì Ì î Î ǐ Ǐ j J k K l L m M n N ó Ó o O ò Ò ô Ô ǒ Ǒ p P r R s S t T ú Ú u U ù Ù û Û ǔ Ǔ v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̂ ◌̌"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/gde_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gde_Latn.textproto
@@ -1,0 +1,7 @@
+id: "gde_Latn"
+language: "gde"
+script: "Latn"
+name: "Gude"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɓ Ɓ ɗ Ɗ ə Ə"
+}

--- a/Lib/gflanguages/data/languages/gej_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gej_Latn.textproto
@@ -1,0 +1,8 @@
+id: "gej_Latn"
+language: "gej"
+script: "Latn"
+name: "Gen"
+exemplar_chars {
+  base: "a A b B c C d D ɖ Ɖ e E ɛ Ɛ f F g G ɣ Ɣ h H x X i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q r R"
+}

--- a/Lib/gflanguages/data/languages/gel_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gel_Latn.textproto
@@ -1,0 +1,9 @@
+id: "gel_Latn"
+language: "gel"
+script: "Latn"
+name: "ut-Ma’in"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D e E è È é É f F g G h H i I ì Ì í Í j J k K l L m M n N ń Ń o O ò Ò ó Ó p P r R s S t T u U ù Ù ú Ú w W y Y z Z"
+  marks: "◌̀ ◌́ ◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/gkn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gkn_Latn.textproto
@@ -1,0 +1,9 @@
+id: "gkn_Latn"
+language: "gkn"
+script: "Latn"
+name: "Gokana"
+exemplar_chars {
+  base: "a A à À á Á ã Ã b B c C d D e E è È é É ẹ Ẹ ẽ Ẽ f F g G h H i I ì Ì í Í ĩ Ĩ j J k K l L m M ḿ Ḿ n N ǹ Ǹ ń Ń o O ò Ò ó Ó ọ Ọ õ Õ ṍ Ṍ p P r R s S t T u U ù Ù ú Ú ũ Ũ ṹ Ṹ v V w W y Y z Z"
+  marks: "◌̀ ◌́ ◌̃ ◌̣ ◌̄"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/gmm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gmm_Latn.textproto
@@ -1,0 +1,9 @@
+id: "gmm_Latn"
+language: "gmm"
+script: "Latn"
+name: "Gbaya-Mbodomo"
+exemplar_chars {
+  base: "a A ɓ Ɓ d D ɗ Ɗ e E ɛ Ɛ f F g G b B h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̧"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/gmv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gmv_Latn.textproto
@@ -1,0 +1,7 @@
+id: "gmv_Latn"
+language: "gmv"
+script: "Latn"
+name: "Gamo"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/gnd_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gnd_Latn.textproto
@@ -1,0 +1,8 @@
+id: "gnd_Latn"
+language: "gnd"
+script: "Latn"
+name: "Zulgo-Gemzek"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ e E ə Ə f F g G h H i I k K l L m M n N ŋ Ŋ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J o O q Q x X"
+}

--- a/Lib/gflanguages/data/languages/gng_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gng_Latn.textproto
@@ -1,0 +1,9 @@
+id: "gng_Latn"
+language: "gng"
+script: "Latn"
+name: "Ngangam"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D e E è È é É ɛ Ɛ f F g G h H i I ì Ì í Í j J k K l L m M n N ñ Ñ ŋ Ŋ o O ò Ò ó Ó ɔ Ɔ p P r R s S t T u U ù Ù ú Ú w W y Y ꞌ Ꞌ"
+  marks: "◌̀ ◌́ ◌̃ ◌̀ ◌́"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/god_Latn.textproto
+++ b/Lib/gflanguages/data/languages/god_Latn.textproto
@@ -1,0 +1,9 @@
+id: "god_Latn"
+language: "god"
+script: "Latn"
+name: "Godié"
+exemplar_chars {
+  base: "a A ä Ä b B d D e E ɛ Ɛ f F g G i I ï Ï ɩ Ɩ k K l L m M n N ŋ Ŋ o O ö Ö ɔ Ɔ p P s S t T u U ü Ü ʋ Ʋ v V w W y Y z Z"
+  marks: "◌̈"
+  auxiliary: "c C j J q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/gof_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gof_Latn.textproto
@@ -1,0 +1,7 @@
+id: "gof_Latn"
+language: "gof"
+script: "Latn"
+name: "Gofa"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/gqr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gqr_Latn.textproto
@@ -1,0 +1,7 @@
+id: "gqr_Latn"
+language: "gqr"
+script: "Latn"
+name: "Gor"
+exemplar_chars {
+  base: "a A b B d D e E g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y ɓ Ɓ ɔ Ɔ ɗ Ɗ ə Ə ɨ Ɨ"
+}

--- a/Lib/gflanguages/data/languages/gud_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gud_Latn.textproto
@@ -1,0 +1,8 @@
+id: "gud_Latn"
+language: "gud"
+script: "Latn"
+name: "Dida, Yocoboué"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/guk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/guk_Latn.textproto
@@ -1,0 +1,8 @@
+id: "guk_Latn"
+language: "guk"
+script: "Latn"
+name: "Gumuz"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y z Z"
+  auxiliary: "f F p P q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/guw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/guw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "guw_Latn"
+language: "guw"
+script: "Latn"
+name: "Gun"
+exemplar_chars {
+  base: "a A b B c C d D ɗ Ɗ e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ s S t T u U v V w W x X y Y z Z"
+  auxiliary: "p P q Q r R"
+}

--- a/Lib/gflanguages/data/languages/gux_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gux_Latn.textproto
@@ -1,0 +1,9 @@
+id: "gux_Latn"
+language: "gux"
+script: "Latn"
+name: "Gourmanchéma"
+exemplar_chars {
+  base: "a A á Á ā Ā b B c C d D e E é É ē Ē f F g G h H i I í Í ī Ī j J k K l L m M n N ŋ Ŋ o O ó Ó ō Ō ɔ Ɔ p P s S t T u U ú Ú ū Ū w W y Y"
+  marks: "◌́ ◌̄ ◌̃"
+  auxiliary: "q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/gyi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/gyi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "gyi_Latn"
+language: "gyi"
+script: "Latn"
+name: "Gyele"
+exemplar_chars {
+  base: "a A b B d D e E f F g G i I k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C h H j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/hag_Latn.textproto
+++ b/Lib/gflanguages/data/languages/hag_Latn.textproto
@@ -1,0 +1,8 @@
+id: "hag_Latn"
+language: "hag"
+script: "Latn"
+name: "Hanga"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "ɛ Ɛ ɔ Ɔ q Q x X"
+}

--- a/Lib/gflanguages/data/languages/hia_Latn.textproto
+++ b/Lib/gflanguages/data/languages/hia_Latn.textproto
@@ -1,0 +1,8 @@
+id: "hia_Latn"
+language: "hia"
+script: "Latn"
+name: "Lamang"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ǝ Ǝ f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/hig_Latn.textproto
+++ b/Lib/gflanguages/data/languages/hig_Latn.textproto
@@ -1,0 +1,9 @@
+id: "hig_Latn"
+language: "hig"
+script: "Latn"
+name: "Kamwe"
+exemplar_chars {
+  base: "a A á Á b B ɓ Ɓ c C d D ɗ Ɗ e E ə Ə f F g G h H i I í Í j J k K l L m M n N o O ó Ó p P r R s S t T u U ú Ú v V w W y Y z Z"
+  marks: "◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/iby_Latn.textproto
+++ b/Lib/gflanguages/data/languages/iby_Latn.textproto
@@ -1,0 +1,9 @@
+id: "iby_Latn"
+language: "iby"
+script: "Latn"
+name: "Ibani"
+exemplar_chars {
+  base: "á Á ā Ā a A b B ḅ Ḅ d D é É ē Ē e E ẹ Ẹ f F g G h H í Í ī Ī i I ị Ị j J k K l L m M ḿ Ḿ ń Ń n N ó Ó ō Ō o O ọ Ọ p P r R s S t T ú Ú ū Ū u U ụ Ụ v V w W y Y z Z"
+  marks: "◌́ ◌̄ ◌̣"
+  auxiliary: "c C q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ica_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ica_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ica_Latn"
+language: "ica"
+script: "Latn"
+name: "Ede Ica"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y"
+  marks: "◌́ ◌̀"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ich_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ich_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ich_Latn"
+language: "ich"
+script: "Latn"
+name: "Etkywan"
+exemplar_chars {
+  base: "a A à À ā Ā á Á b B c C d D e E è È ē Ē é É ɛ Ɛ f F g G h H i I ì Ì ī Ī í Í j J k K l L m M n N o O ò Ò ō Ō ó Ó ɔ Ɔ p P r R s S t T u U ù Ù ū Ū ú Ú v V w W y Y z Z"
+  marks: "◌̀ ◌̄ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/idd_Latn.textproto
+++ b/Lib/gflanguages/data/languages/idd_Latn.textproto
@@ -1,0 +1,9 @@
+id: "idd_Latn"
+language: "idd"
+script: "Latn"
+name: "Ede Idaca"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y"
+  marks: "◌́ ◌̀"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/igb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/igb_Latn.textproto
@@ -1,0 +1,9 @@
+id: "igb_Latn"
+language: "igb"
+script: "Latn"
+name: "Ebira"
+exemplar_chars {
+  base: "a A á Á ā Ā à À â Â b B c C d D e E é É ē Ē è È ê Ê ẹ Ẹ ệ Ệ f F g G h H i I í Í ī Ī ì Ì î Î ị Ị j J k K l L m M n N o O ó Ó ō Ō ò Ò ô Ô ọ Ọ ộ Ộ p P r R s S t T u U ú Ú ū Ū ù Ù û Û ụ Ụ v V w W y Y z Z"
+  marks: "◌́ ◌̄ ◌̀ ◌̂ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ige_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ige_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ige_Latn"
+language: "ige"
+script: "Latn"
+name: "Igede"
+exemplar_chars {
+  base: "á Á a A ā Ā à À b B c C d D é É e E è È ẹ Ẹ f F g G h H í Í i I ì Ì ị Ị j J k K l L m M n N ó Ó o O ò Ò ọ Ọ p P r R s S t T ú Ú u U ù Ù ụ Ụ v V w W y Y z Z"
+  marks: "◌́ ◌̄ ◌̀ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ijj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ijj_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ijj_Latn"
+language: "ijj"
+script: "Latn"
+name: "Ede Ije"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y"
+  marks: "◌́ ◌̀"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ikk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ikk_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ikk_Latn"
+language: "ikk"
+script: "Latn"
+name: "Ika"
+exemplar_chars {
+  base: "a A b B c C d D e E ẹ Ẹ f F g G h H i I ị Ị j J k K l L m M n N ṅ Ṅ o O ó Ó ọ Ọ p P r R s S t T u U ụ Ụ v V w W y Y z Z"
+  marks: "◌̣ ◌̇ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ikw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ikw_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ikw_Latn"
+language: "ikw"
+script: "Latn"
+name: "Ikwere"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ẹ Ẹ f F g G h H i I í Í ị Ị j J k K l L m M n N o O ó Ó ọ Ọ p P r R s S t T u U ú Ú ụ Ụ v V w W y Y z Z"
+  marks: "◌́ ◌̣ ◌̄"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ikx_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ikx_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ikx_Latn"
+language: "ikx"
+script: "Latn"
+name: "Ik"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J ʝ Ʝ k K ƙ Ƙ l L m M n N ɲ Ɲ ŋ Ŋ o O p P r R s S t T u U w W x X y Y z Z"
+  auxiliary: "q Q v V"
+}

--- a/Lib/gflanguages/data/languages/iqw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/iqw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "iqw_Latn"
+language: "iqw"
+script: "Latn"
+name: "Ikwo"
+exemplar_chars {
+  base: "a A b B c C d D e E ẹ Ẹ f F g G h H i I ị Ị j J k K l L m M n N o O ọ Ọ p P r R s S t T u U ụ Ụ v V w W y Y z Z"
+  marks: "◌̣ ◌̀ ◌́"
+}

--- a/Lib/gflanguages/data/languages/iri_Latn.textproto
+++ b/Lib/gflanguages/data/languages/iri_Latn.textproto
@@ -1,0 +1,9 @@
+id: "iri_Latn"
+language: "iri"
+script: "Latn"
+name: "Rigwe"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ē Ē è È f F g G h H i I í Í j J k K l L m M n N o O ó Ó p P r R s S t T u U ú Ú v V w W y Y z Z"
+  marks: "◌́ ◌̱ ◌̄ ◌̀ ◌̀ ◌̂ ◌̄ ◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/izr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/izr_Latn.textproto
@@ -1,0 +1,9 @@
+id: "izr_Latn"
+language: "izr"
+script: "Latn"
+name: "Izere"
+exemplar_chars {
+  base: "a A á Á à À b B c C d D e E é É è È f F g G h H i I í Í ì Ì j J k K l L m M n N o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌́ ◌̀"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/izz_Latn.textproto
+++ b/Lib/gflanguages/data/languages/izz_Latn.textproto
@@ -1,0 +1,9 @@
+id: "izz_Latn"
+language: "izz"
+script: "Latn"
+name: "Izii"
+exemplar_chars {
+  base: "a A á Á à À ạ Ạ b B c C d D e E é É è È ẹ Ẹ f F g G h H i I í Í ì Ì ị Ị j J k K l L m M ḿ Ḿ n N ń Ń ǹ Ǹ o O ó Ó ò Ò ọ Ọ p P r R s S t T u U ú Ú ù Ù ụ Ụ v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̣ ◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/jab_Latn.textproto
+++ b/Lib/gflanguages/data/languages/jab_Latn.textproto
@@ -1,0 +1,9 @@
+id: "jab_Latn"
+language: "jab"
+script: "Latn"
+name: "Hyam"
+exemplar_chars {
+  base: "á Á a A à À â Â ǎ Ǎ b B c C d D é É e E è È ê Ê ě Ě f F g G h H í Í i I ì Ì î Î ǐ Ǐ ī Ī j J k K l L m M n N ó Ó o O ò Ò ô Ô ǒ Ǒ ō Ō p P r R s S t T ú Ú u U ù Ù û Û ǔ Ǔ v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̂ ◌̌ ◌̱ ◌̄"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/jbu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/jbu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "jbu_Latn"
+language: "jbu"
+script: "Latn"
+name: "Jukun Takum"
+exemplar_chars {
+  base: "á Á ā Ā a A à À â Â b B ḅ Ḅ c C d D é É ē Ē e E è È ê Ê f F g G h H í Í ī Ī i I ì Ì î Î j J k K ḳ Ḳ l L ḿ Ḿ m M ń Ń n N ǹ Ǹ ó Ó ō Ō o O ò Ò ô Ô p P r R s S t T ú Ú ū Ū u U ù Ù û Û v V w W y Y z Z"
+  marks: "◌́ ◌̄ ◌̀ ◌̂ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/jen_Latn.textproto
+++ b/Lib/gflanguages/data/languages/jen_Latn.textproto
@@ -1,0 +1,9 @@
+id: "jen_Latn"
+language: "jen"
+script: "Latn"
+name: "Dza"
+exemplar_chars {
+  base: "a A à À ǎ Ǎ ã Ã b B c C d D e E è È ě Ě ẽ Ẽ ɛ Ɛ ǝ Ǝ f F g G h H i I ì Ì ǐ Ǐ ĩ Ĩ ɨ Ɨ j J k K l L m M n N o O ò Ò ǒ Ǒ õ Õ ɔ Ɔ p P r R s S t T u U ù Ù ǔ Ǔ ũ Ũ v V w W y Y z Z"
+  marks: "◌̀ ◌̌ ◌̃"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/jgk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/jgk_Latn.textproto
@@ -1,0 +1,8 @@
+id: "jgk_Latn"
+language: "jgk"
+script: "Latn"
+name: "Gwak"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ǝ Ǝ g G i I j J k K l L m M n N o O p P r R s S t T u U w W y Y z Z"
+  auxiliary: "f F h H q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/jib_Latn.textproto
+++ b/Lib/gflanguages/data/languages/jib_Latn.textproto
@@ -1,0 +1,9 @@
+id: "jib_Latn"
+language: "jib"
+script: "Latn"
+name: "Jibu"
+exemplar_chars {
+  base: "a A á Á à À b B c C d D e E é É è È f F g G h H i I í Í ì Ì j J k K l L m M ḿ Ḿ n N ń Ń ǹ Ǹ o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌́ ◌̀"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/kad_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kad_Latn.textproto
@@ -1,0 +1,9 @@
+id: "kad_Latn"
+language: "kad"
+script: "Latn"
+name: "Adara"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/kai_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kai_Latn.textproto
@@ -1,0 +1,7 @@
+id: "kai_Latn"
+language: "kai"
+script: "Latn"
+name: "Karekare"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ǝ Ǝ f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y ƴ Ƴ z Z"
+}

--- a/Lib/gflanguages/data/languages/kbp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kbp_Latn.textproto
@@ -3,6 +3,11 @@ language: "kbp"
 script: "Latn"
 name: "Kabiyé"
 region: "TG"
+exemplar_chars {
+	base: "a A b B c C d D ɖ Ɖ e E ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ñ Ñ ŋ Ŋ o O ɔ Ɔ p P s S t T u U ʋ Ʋ v V w W y Y z Z ɣ Ɣ"
+	marks: "◌̃"
+	auxiliary: "q Q r R x X"
+}
 sample_text {
   masthead_full: "PpAa"
   masthead_partial: "Ll"

--- a/Lib/gflanguages/data/languages/kby_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kby_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kby_Latn"
+language: "kby"
+script: "Latn"
+name: "Kanuri, Manga"
+exemplar_chars {
+  base: "a A b B c C d D e E ǝ Ǝ f F g G h H i I j J k K l L m M n N o O p P r R ɍ Ɍ s S t T u U w W y Y"
+  auxiliary: "z Z"
+}

--- a/Lib/gflanguages/data/languages/kdc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kdc_Latn.textproto
@@ -1,0 +1,7 @@
+id: "kdc_Latn"
+language: "kdc"
+script: "Latn"
+name: "Kutu"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/kdh_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kdh_Latn.textproto
@@ -3,6 +3,11 @@ language: "kdh"
 script: "Latn"
 name: "Tem"
 region: "TG"
+exemplar_chars {
+	base: "a A á Á b B c C d D ɖ Ɖ e E é É ɛ Ɛ f F g G h H i I í Í ɩ Ɩ j J k K l L m M ḿ Ḿ ÿ Ÿ n N ń Ń ŋ Ŋ o O ó Ó ɔ Ɔ p P r R s S t T u U ú Ú ʊ Ʊ v V w W y Y z Z"
+	marks: "◌́ ◌̈ ◌́"
+	auxiliary: "q Q x X"
+}
 sample_text {
   masthead_full: "BbÁá"
   masthead_partial: "Nn"

--- a/Lib/gflanguages/data/languages/kdl_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kdl_Latn.textproto
@@ -1,0 +1,9 @@
+id: "kdl_Latn"
+language: "kdl"
+script: "Latn"
+name: "Tsikimba"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ꞌ Ꞌ"
+  marks: "◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ken_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ken_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ken_Latn"
+language: "ken"
+script: "Latn"
+name: "Kenyang"
+exemplar_chars {
+  base: "a A á Á à À ǎ Ǎ b B d D e E é É è È ě Ě ɛ Ɛ f F g G i I í Í ì Ì ǐ Ǐ ɨ Ɨ j J k K m M n N ŋ Ŋ o O ó Ó ò Ò ǒ Ǒ ɔ Ɔ p P r R s S t T u U ú Ú ù Ù ǔ Ǔ ʉ Ʉ w W y Y"
+  marks: "◌́ ◌̀ ◌̌"
+  auxiliary: "c C h H l L q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/kez_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kez_Latn.textproto
@@ -1,0 +1,9 @@
+id: "kez_Latn"
+language: "kez"
+script: "Latn"
+name: "Kukele"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D e E è È é É ɛ Ɛ f F g G h H i I ì Ì í Í j J k K l L m M n N o O ò Ò ó Ó ɔ Ɔ p P r R s S t T u U ù Ù ú Ú v V w W y Y z Z"
+  marks: "◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/khq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/khq_Latn.textproto
@@ -6,9 +6,9 @@ autonym: "Koyra Chiini"
 population: 332407
 region: "ML"
 exemplar_chars {
-  base: "a ã b c d e ẽ f g h i j k l m n ɲ ŋ o õ p q r s š t u w x y z ž"
-  auxiliary: "v"
-  marks: "◌̃ ◌̌"
+	base: "a A b B c C d D e E ẽ Ẽ f F g G h H i I j J k K l L m M n N ɲ Ɲ ŋ Ŋ o O õ Õ p P q Q r R s S š Š t T u U w W x X y Y z Z ž Ž"
+	marks: "◌̃ ◌̌"
+	auxiliary: "v V"
   numerals: "  - ‑ . % ‰ + 0 1 2 3 4 5 6 7 8 9"
   index: "A Ã B C D E Ẽ F G H I J K L M N Ɲ Ŋ O Õ P Q R S Š T U W X Y Z Ž"
 }

--- a/Lib/gflanguages/data/languages/kkj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kkj_Latn.textproto
@@ -6,9 +6,9 @@ autonym: "Kakɔ"
 population: 149823
 region: "CM"
 exemplar_chars {
-  base: "a á à â {a̧} b ɓ c d ɗ {ɗy} e é è ê ɛ {ɛ́} {ɛ̀} {ɛ̂} {ɛ̧} f g {gb} {gw} h i í ì î {i̧} j k {kp} {kw} l m {mb} n {nd} ǌ {ny} ŋ {ŋg} {ŋgb} {ŋgw} o ó ò ô ɔ {ɔ́} {ɔ̀} {ɔ̂} {ɔ̧} p r s t u ú ù û {u̧} v w y"
-  auxiliary: "q x z"
-  marks: "◌̀ ◌́ ◌̂ ◌̧"
+  base: "a á à â {a̧} b ɓ c d ɗ {ɗy} e é è ê ɛ {ɛ́} {ɛ̀} {ɛ̂} {ɛ̧} f g {gb} {gw} h i í ì î {i̧} j k {kp} {kw} l m {mb} n {nd} ǌ {ny} ŋ {ŋg} {ŋgb} {ŋgw} o ó ò ô ɔ {ɔ́} {ɔ̀} {ɔ̂} {ɔ̧} p r s t u ú ù û {u̧} v w y "A Á À Â {A̧} B Ɓ C D Ɗ {Ɗy} E É È Ê Ɛ {Ɛ́} {Ɛ̀} {Ɛ̂} {Ɛ̧} F G {Gb} {Gw} H I Í Ì Î {I̧} J K {Kp} {Kw} L M {Mb} N {Nd} Ǌ {Ny} Ŋ {Ŋg} {Ŋgb} {Ŋgw} O Ó Ò Ô Ɔ {Ɔ́} {Ɔ̀} {Ɔ̂} {Ɔ̧} P R S T U Ú Ù Û {U̧} V W Y""
+  auxiliary: "q Q x X z Z"
+  marks: "◌́ ◌̀ ◌̂ ◌̧ ◌̀ ◌́ ◌̂ ◌̧ ◌̌"
   numerals: "- ‑ , . % ‰ + 0 1 2 3 4 5 6 7 8 9"
   punctuation: ", : ! ? . … ‘ ‹ › “ ” « » ( ) *"
   index: "A B Ɓ C D Ɗ {Ɗy} E Ɛ F G {Gb} {Gw} H I {I̧} J K {Kp} {Kw} L M {Mb} N {Nd} ǋ {Ny} Ŋ {Ŋg} {Ŋgb} {Ŋgw} O Ɔ {Ɔ̧} P R S T U {U̧} V W Y"

--- a/Lib/gflanguages/data/languages/kmy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kmy_Latn.textproto
@@ -1,0 +1,7 @@
+id: "kmy_Latn"
+language: "kmy"
+script: "Latn"
+name: "Koma"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ɩ Ɩ ʋ Ʋ"
+}

--- a/Lib/gflanguages/data/languages/knf_Latn.textproto
+++ b/Lib/gflanguages/data/languages/knf_Latn.textproto
@@ -5,6 +5,7 @@ name: "Mankanya"
 population: 83151
 region: "GW"
 region: "SN"
-exemplar_chars {
-  base: "a b c d e ë f g h i j k l m n ñ ŋ o p r s ş t ŧ ţ u w y"
+  base: "a A b B c C d D e E ë Ë f F g G h H i I j J k K l L m M n N ñ Ñ ŋ Ŋ o O p P r R ş Ş t T ţ Ţ ŧ Ŧ u U ú Ú w W y Y"
+  marks: "◌̈ ◌̃ ◌̧ ◌́"
+  auxiliary: "q Q s S v V x X z Z"
 }

--- a/Lib/gflanguages/data/languages/knp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/knp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "knp_Latn"
+language: "knp"
+script: "Latn"
+name: "Kwanja"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ ə Ə f F g G h H i I ɨ Ɨ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʉ Ʉ v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/kpo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kpo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kpo_Latn"
+language: "kpo"
+script: "Latn"
+name: "Ikposo"
+exemplar_chars {
+  base: "a A ǝ Ǝ b B d D e E ɛ Ɛ f F g G ɣ Ɣ h H i I ɩ Ɩ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʊ Ʊ v V w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/kqp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kqp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kqp_Latn"
+language: "kqp"
+script: "Latn"
+name: "Kimré"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D e E é É ê Ê g G h H i I j J k K l L m M n N o O ô Ô p P r R s S t T u U w W y Y ŋ Ŋ ɓ Ɓ ɗ Ɗ ɲ Ɲ"
+  marks: "◌̀ ◌́ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/krs_Latn.textproto
+++ b/Lib/gflanguages/data/languages/krs_Latn.textproto
@@ -1,0 +1,9 @@
+id: "krs_Latn"
+language: "krs"
+script: "Latn"
+name: "Gbaya"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L ḷ Ḷ m M n N ŋ Ŋ o O p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ksp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ksp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ksp_Latn"
+language: "ksp"
+script: "Latn"
+name: "Kabba"
+exemplar_chars {
+  base: "a A b B d D e E g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y ɔ Ɔ"
+  marks: "◌̍ ◌̠ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/ktj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ktj_Latn.textproto
@@ -1,0 +1,7 @@
+id: "ktj_Latn"
+language: "ktj"
+script: "Latn"
+name: "Krumen, Plapo"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y ŋ Ŋ ɔ Ɔ ɛ Ɛ ɩ Ɩ ʋ Ʋ"
+}

--- a/Lib/gflanguages/data/languages/kub_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kub_Latn.textproto
@@ -1,0 +1,9 @@
+id: "kub_Latn"
+language: "kub"
+script: "Latn"
+name: "Kutep"
+exemplar_chars {
+  base: "á Á ā Ā a A b B c C d D é É ē Ē e E f F g G h H í Í ī Ī i I j J k K l L ḿ Ḿ m M ń Ń n N ó Ó ō Ō o O p P r R s S t T ú Ú ū Ū u U v V w W y Y z Z"
+  marks: "◌́ ◌̄"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/kuj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kuj_Latn.textproto
@@ -1,0 +1,9 @@
+id: "kuj_Latn"
+language: "kuj"
+script: "Latn"
+name: "Kuria"
+exemplar_chars {
+  base: "a A b B e E ë Ë g G h H i I k K m M n N o O ö Ö r R s S t T u U w W y Y"
+  marks: "◌̈"
+  auxiliary: "c C d D f F j J l L p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/kun_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kun_Latn.textproto
@@ -1,0 +1,9 @@
+id: "kun_Latn"
+language: "kun"
+script: "Latn"
+name: "Kunama"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N ñ Ñ o O r R s S š Š t T u U w W y Y"
+  marks: "◌̃ ◌̌"
+  auxiliary: "p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/kus_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kus_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kus_Latn"
+language: "kus"
+script: "Latn"
+name: "Kusaal"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I k K l L m M n N ŋ Ŋ o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/kvf_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kvf_Latn.textproto
@@ -1,0 +1,7 @@
+id: "kvf_Latn"
+language: "kvf"
+script: "Latn"
+name: "Kabalai"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W x X y Y z Z ŋ Ŋ ɔ Ɔ ɛ Ɛ ɩ Ɩ ʋ Ʋ"
+}

--- a/Lib/gflanguages/data/languages/kye_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kye_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kye_Latn"
+language: "kye"
+script: "Latn"
+name: "Krache"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F i I ɩ Ɩ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ w W y Y"
+  auxiliary: "h H j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/kyf_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kyf_Latn.textproto
@@ -1,0 +1,7 @@
+id: "kyf_Latn"
+language: "kyf"
+script: "Latn"
+name: "Kouya"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W x X y Y z Z ŋ Ŋ ɔ Ɔ ɛ Ɛ ɩ Ɩ ʋ Ʋ"
+}

--- a/Lib/gflanguages/data/languages/kyq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kyq_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kyq_Latn"
+language: "kyq"
+script: "Latn"
+name: "Kenga"
+exemplar_chars {
+  base: "a A b B c C d D e E g G i I j J k K l L m M n N o O p P r R s S t T u U w W y Y z Z ŋ Ŋ ƴ Ƴ ɓ Ɓ ɔ Ɔ ɗ Ɗ ɛ Ɛ"
+  marks: "◌̰"
+}

--- a/Lib/gflanguages/data/languages/kzr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kzr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "kzr_Latn"
+language: "kzr"
+script: "Latn"
+name: "Karang"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ e E f F g G h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y ƴ Ƴ z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/las_Latn.textproto
+++ b/Lib/gflanguages/data/languages/las_Latn.textproto
@@ -1,0 +1,9 @@
+id: "las_Latn"
+language: "las"
+script: "Latn"
+name: "Lama"
+exemplar_chars {
+  base: "a A c C ɖ Ɖ ǝ Ǝ e E ɛ Ɛ f F h H i I ɨ Ɨ ɩ Ɩ k K l L m M n N ñ Ñ ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ w W y Y"
+  marks: "◌̃"
+  auxiliary: "b B d D g G j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ldb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ldb_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ldb_Latn"
+language: "ldb"
+script: "Latn"
+name: "Duya"
+exemplar_chars {
+  base: "a A ã Ã b B c C d D e E ẽ Ẽ ɛ Ɛ f F g G h H i I ĩ Ĩ j J k K l L m M n N o O õ Õ ɔ Ɔ p P r R s S t T u U ũ Ũ v V w W y Y z Z"
+  marks: "◌̃"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/led_Latn.textproto
+++ b/Lib/gflanguages/data/languages/led_Latn.textproto
@@ -1,0 +1,8 @@
+id: "led_Latn"
+language: "led"
+script: "Latn"
+name: "Lendu"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I ɨ Ɨ j J k K l L m M n N o O ø Ø p P r R s S t T u U ʉ Ʉ v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/lee_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lee_Latn.textproto
@@ -1,0 +1,9 @@
+id: "lee_Latn"
+language: "lee"
+script: "Latn"
+name: "Lyélé"
+exemplar_chars {
+  base: "a A â Â b B c C d D e E ê Ê f F g G h H i I j J k K l L m M n N o O ô Ô p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ə Ə ɛ Ɛ"
+  marks: "◌̂ ◌̀ ◌́ ◌̃ ◌̌"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/lem_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lem_Latn.textproto
@@ -1,0 +1,9 @@
+id: "lem_Latn"
+language: "lem"
+script: "Latn"
+name: "Nomaande"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ɛ Ɛ f F g G h H i I í Í n N j J k K l L m M ŋ Ŋ o O ó Ó ɔ Ɔ s S t T u U ú Ú w W y Y"
+  marks: "◌́ ◌́"
+  auxiliary: "n N p P q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/les_Latn.textproto
+++ b/Lib/gflanguages/data/languages/les_Latn.textproto
@@ -1,0 +1,7 @@
+id: "les_Latn"
+language: "les"
+script: "Latn"
+name: "Lese"
+exemplar_chars {
+  base: "a A b B d D e E f F g G i I ɨ Ɨ k K l L m M n N o O p P s S t T u U ʉ Ʉ v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/lgg_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lgg_Latn.textproto
@@ -1,0 +1,9 @@
+id: "lgg_Latn"
+language: "lgg"
+script: "Latn"
+name: "Lugbara"
+exemplar_chars {
+  base: "a A ä Ä b B c C d D e E ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  marks: "◌̈"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/lig_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lig_Latn.textproto
@@ -1,0 +1,8 @@
+id: "lig_Latn"
+language: "lig"
+script: "Latn"
+name: "Ligbi"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U v V w W y Y"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/lip_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lip_Latn.textproto
@@ -1,0 +1,8 @@
+id: "lip_Latn"
+language: "lip"
+script: "Latn"
+name: "Sekpele"
+exemplar_chars {
+  base: "a A à À b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ǝ Ǝ ɔ Ɔ ɛ Ɛ"
+  marks: "◌̀ ◌́ ◌̃"
+}

--- a/Lib/gflanguages/data/languages/lln_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lln_Latn.textproto
@@ -1,0 +1,8 @@
+id: "lln_Latn"
+language: "lln"
+script: "Latn"
+name: "Lele"
+exemplar_chars {
+  base: "a A b B c C d D e E g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y"
+  auxiliary: "f F q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/lmp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lmp_Latn.textproto
@@ -1,0 +1,9 @@
+id: "lmp_Latn"
+language: "lmp"
+script: "Latn"
+name: "Limbum"
+exemplar_chars {
+  base: "a A à À â Â ǎ Ǎ b B c C d D e E è È ê Ê ě Ě ɛ Ɛ f F g G h H i I ì Ì î Î ǐ Ǐ j J k K l L m M n N ŋ Ŋ o O ò Ò ô Ô ǒ Ǒ p P r R s S t T u U ù Ù û Û ǔ Ǔ ʉ Ʉ v V w W y Y"
+  marks: "◌̀ ◌̂ ◌̌"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/lnu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lnu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "lnu_Latn"
+language: "lnu"
+script: "Latn"
+name: "Longuda"
+exemplar_chars {
+  base: "a A ā Ā b B c C d D e E f F g G h H i I j J k K l L m M n N ṉ Ṉ o O p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̄ ◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/log_Latn.textproto
+++ b/Lib/gflanguages/data/languages/log_Latn.textproto
@@ -1,0 +1,8 @@
+id: "log_Latn"
+language: "log"
+script: "Latn"
+name: "Logo"
+exemplar_chars {
+  base: "a A ä Ä b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɨ Ɨ ꞌ Ꞌ"
+  marks: "◌̈ ◌̀ ◌́ ◌̌"
+}

--- a/Lib/gflanguages/data/languages/lok_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lok_Latn.textproto
@@ -1,0 +1,8 @@
+id: "lok_Latn"
+language: "lok"
+script: "Latn"
+name: "Loko"
+exemplar_chars {
+  base: "a A b B e E ɛ Ɛ f F g G h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U w W y Y"
+  auxiliary: "d D j J q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/loq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/loq_Latn.textproto
@@ -1,0 +1,8 @@
+id: "loq_Latn"
+language: "loq"
+script: "Latn"
+name: "Lobala"
+exemplar_chars {
+  base: "a A b B d D e E é É f F g G h H i I k K l L m M n N o O ó Ó p P s S t T u U v V w W y Y z Z ŋ Ŋ ɓ Ɓ ɔ Ɔ ɛ Ɛ"
+  marks: "◌́ ◌̀"
+}

--- a/Lib/gflanguages/data/languages/lor_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lor_Latn.textproto
@@ -1,0 +1,9 @@
+id: "lor_Latn"
+language: "lor"
+script: "Latn"
+name: "Téén"
+exemplar_chars {
+  base: "a A ä Ä b B c C d D e E ɛ Ɛ f F g G x X h H i I ɩ Ɩ j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  marks: "◌̈"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/lwo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lwo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "lwo_Latn"
+language: "lwo"
+script: "Latn"
+name: "Luwo"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E g G h H i I j J k K l L m M n N o O p P r R t T u U w W y Y"
+  marks: "◌́"
+}

--- a/Lib/gflanguages/data/languages/maw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/maw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "maw_Latn"
+language: "maw"
+script: "Latn"
+name: "Mampruli"
+exemplar_chars {
+  base: "a A b B d D ɛ Ɛ e E f F g G h H i I o O k K l L m M n N ŋ Ŋ ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mbo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mbo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mbo_Latn"
+language: "mbo"
+script: "Latn"
+name: "Mbo"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D e E ɛ Ɛ g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U w W y Y z Z"
+  auxiliary: "c C f F q Q r R v V x X"
+}

--- a/Lib/gflanguages/data/languages/mbu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mbu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mbu_Latn"
+language: "mbu"
+script: "Latn"
+name: "Mbula-Bwazza"
+exemplar_chars {
+  base: "a A â Â b B ɓ Ɓ ā Ā ǎ Ǎ c C d D ɗ Ɗ e E ǝ Ǝ ê Ê f F ě Ě g G h H i I j J k K ƙ Ƙ î Î l L m M n N o O p P r R ô Ô s S ǒ Ǒ t T u U v V w W y Y z Z û Û ū Ū ǔ Ǔ ŋ Ŋ"
+  marks: "◌̂ ◌̄ ◌̌ ◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mcp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mcp_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mcp_Latn"
+language: "mcp"
+script: "Latn"
+name: "Makaa"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ə Ə ɛ Ɛ ɨ Ɨ ʉ Ʉ"
+  marks: "◌̧ ◌́ ◌̂ ◌̌"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/mcu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mcu_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mcu_Latn"
+language: "mcu"
+script: "Latn"
+name: "Mambila, Cameroon"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/mda_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mda_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mda_Latn"
+language: "mda"
+script: "Latn"
+name: "Mada"
+exemplar_chars {
+  base: "a A à À ā Ā â Â ă Ă b B c C d D e E é É ē Ē è È ê Ê ĕ Ĕ ə Ə ɛ Ɛ f F g G h H i I ī Ī ì Ì î Î ĭ Ĭ j J k K l L m M n N o O ō Ō ò Ò ô Ô ŏ Ŏ ɔ Ɔ p P r R s S t T u U ū Ū ù Ù û Û ŭ Ŭ v V w W y Y z Z"
+  marks: "◌̀ ◌̄ ◌̂ ◌̆ ◌́ ◌̀ ◌̂ ◌̄ ◌̆"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mdj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mdj_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mdj_Latn"
+language: "mdj"
+script: "Latn"
+name: "Mangbetu"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I ɨ Ɨ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʉ Ʉ v V w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/meq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/meq_Latn.textproto
@@ -1,0 +1,8 @@
+id: "meq_Latn"
+language: "meq"
+script: "Latn"
+name: "Merey"
+exemplar_chars {
+  base: "a A â Â b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ œ Œ ɓ Ɓ ɗ Ɗ ə Ə ɨ Ɨ"
+  marks: "◌̂"
+}

--- a/Lib/gflanguages/data/languages/mfi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mfi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mfi_Latn"
+language: "mfi"
+script: "Latn"
+name: "Wandala"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E f F g G h H i I í Í j J k K l L m M n N p P r R s S t T u U ú Ú v V w W y Y z Z ŋ Ŋ ƴ Ƴ ɓ Ɓ ɗ Ɗ ꞌ Ꞌ"
+  marks: "◌́"
+}

--- a/Lib/gflanguages/data/languages/mfn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mfn_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mfn_Latn"
+language: "mfn"
+script: "Latn"
+name: "Mbembe, Cross River"
+exemplar_chars {
+  base: "a A á Á à À b B c C d D e E é É è È ẹ Ẹ f F g G h H i I í Í ì Ì ị Ị j J k K l L m M ḿ Ḿ n N ń Ń o O ó Ó ò Ò ọ Ọ p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̱ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mfo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mfo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mfo_Latn"
+language: "mfo"
+script: "Latn"
+name: "Mbe"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G i I j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U w W y Y"
+  auxiliary: "c C h H q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/mgc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mgc_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mgc_Latn"
+language: "mgc"
+script: "Latn"
+name: "Morokodo"
+exemplar_chars {
+  base: "a A ä Ä b B d D e E ë Ë f F g G h H i I ï Ï j J k K l L m M n N o O ö Ö p P r R ṛ Ṛ s S t T u U ü Ü v V w W y Y z Z ŋ Ŋ ɔ Ɔ"
+  marks: "◌̈ ◌̣"
+}

--- a/Lib/gflanguages/data/languages/mhi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mhi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mhi_Latn"
+language: "mhi"
+script: "Latn"
+name: "Ma’di"
+exemplar_chars {
+  base: "a A ä Ä b B d D ʤ ʤ e E ɛ Ɛ f F g G i I ɩ Ɩ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  marks: "◌̈"
+}

--- a/Lib/gflanguages/data/languages/mkl_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mkl_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mkl_Latn"
+language: "mkl"
+script: "Latn"
+name: "Mokole"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y"
+  marks: "◌́ ◌̀"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/mlt_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mlt_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mlt_Latn"
+language: "mlt"
+script: "Latn"
+name: "Maltese"
+exemplar_chars {
+  base: "a A à À b B ċ Ċ d D e E è È f F ġ Ġ g G h H ħ Ħ i I ì Ì j J k K l L m M n N o O ò Ò p P q Q r R s S t T u U ù Ù v V w W x X ż Ż z Z"
+  marks: "◌̀ ◌̇"
+  auxiliary: "c C y Y"
+}

--- a/Lib/gflanguages/data/languages/mmu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mmu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mmu_Latn"
+language: "mmu"
+script: "Latn"
+name: "Mmaala"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ɛ Ɛ f F g G h H i I í Í k K l L m M n N ŋ Ŋ o O ó Ó ɔ Ɔ p P s S t T u U ú Ú w W y Y"
+  marks: "◌́"
+  auxiliary: "j J q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/mnf_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mnf_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mnf_Latn"
+language: "mnf"
+script: "Latn"
+name: "Mundani"
+exemplar_chars {
+  base: "a A b B d D e E ə Ə f F g G i I ɨ Ɨ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U v V w W y Y z Z"
+  auxiliary: "c C h H j J q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/moa_Latn.textproto
+++ b/Lib/gflanguages/data/languages/moa_Latn.textproto
@@ -1,0 +1,8 @@
+id: "moa_Latn"
+language: "moa"
+script: "Latn"
+name: "Mwan"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ h H f F g G i I j J k K l L m M n N o O ɔ Ɔ p P r R s S ŋ Ŋ t T u U v V w W y Y z Z"
+  auxiliary: "h H q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mqb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mqb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mqb_Latn"
+language: "mqb"
+script: "Latn"
+name: "Mbuko"
+exemplar_chars {
+  base: "a A à À á Á â Â b B c C d D e E é É f F g G h H i I ì Ì î Î j J k K l L m M n N o O ò Ò p P r R s S t T u U ù Ù û Û v V w W y Y z Z œ Œ ɓ Ɓ ɗ Ɗ ə Ə"
+  marks: "◌̀ ◌́ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/mql_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mql_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mql_Latn"
+language: "mql"
+script: "Latn"
+name: "Mbelime"
+exemplar_chars {
+  base: "a A á Á ā Ā b B c C d D e E é É ē Ē ɛ Ɛ f F h H i I í Í ī Ī ḭ Ḭ k K m M n N ń Ń o O ó Ó ō Ō ɔ Ɔ p P s S t T u U ú Ú ū Ū ṵ Ṵ w W y Y"
+  marks: "◌́ ◌̄ ◌̰"
+  auxiliary: "g G j J l L q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/msc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/msc_Latn.textproto
@@ -1,0 +1,7 @@
+id: "msc_Latn"
+language: "msc"
+script: "Latn"
+name: "Maninka, Sankaran"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y ɔ Ɔ ɛ Ɛ ɲ Ɲ"
+}

--- a/Lib/gflanguages/data/languages/muh_Latn.textproto
+++ b/Lib/gflanguages/data/languages/muh_Latn.textproto
@@ -1,0 +1,8 @@
+id: "muh_Latn"
+language: "muh"
+script: "Latn"
+name: "Mündü"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I ï Ï j J k K l L m M n N o O ö Ö p P r R s S t T u U ü Ü v V w W y Y z Z ꞌ Ꞌ"
+  marks: "◌̈"
+}

--- a/Lib/gflanguages/data/languages/mur_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mur_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mur_Latn"
+language: "mur"
+script: "Latn"
+name: "Murle"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ g G i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R t T u U v V w W y Y z Z"
+  marks: "◌̠"
+  auxiliary: "f F h H q Q s S x X"
+}

--- a/Lib/gflanguages/data/languages/muy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/muy_Latn.textproto
@@ -1,0 +1,8 @@
+id: "muy_Latn"
+language: "muy"
+script: "Latn"
+name: "Muyang"
+exemplar_chars {
+  base: "a A á Á â Â b B c C d D e E é É ê Ê f F g G h H i I í Í î Î j J k K l L m M n N o O ô Ô p P r R s S t T u U ú Ú v V w W y Y z Z ŋ Ŋ ɓ Ɓ ɗ Ɗ ə Ə ʉ Ʉ"
+  marks: "◌́ ◌̂ ◌̀"
+}

--- a/Lib/gflanguages/data/languages/myk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/myk_Latn.textproto
@@ -1,0 +1,9 @@
+id: "myk_Latn"
+language: "myk"
+script: "Latn"
+name: "Sénoufo, Mamara"
+exemplar_chars {
+  base: "a A á Á à À b B c C d D e E é É è È ɛ Ɛ f F g G h H i I í Í j J k K l L m M n N ɲ Ɲ ŋ Ŋ o O ò Ò ɔ Ɔ p P r R s S t T u U ú Ú ù Ù v V w W x X y Y z Z"
+  marks: "◌́ ◌̀"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/mym_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mym_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mym_Latn"
+language: "mym"
+script: "Latn"
+name: "Me’en"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ g G h H i I j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U w W y Y z Z"
+  auxiliary: "f F q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/mzk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mzk_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mzk_Latn"
+language: "mzk"
+script: "Latn"
+name: "Mambila, Nigeria"
+exemplar_chars {
+  base: "a A á Á à À b B c C d D e E é É è È f F g G h H i I í Í ì Ì j J k K l L m M n N o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌́ ◌̀"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mzm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mzm_Latn.textproto
@@ -1,0 +1,9 @@
+id: "mzm_Latn"
+language: "mzm"
+script: "Latn"
+name: "Mumuye"
+exemplar_chars {
+  base: "a A á Á à À â Â ǎ Ǎ ã Ã b B ɓ Ɓ c C d D ɗ Ɗ e E é É è È ê Ê ě Ě ɛ Ɛ g G h H i I í Í ì Ì î Î ǐ Ǐ ĩ Ĩ j J k K l L m M n N ǹ Ǹ ň Ň o O ó Ó ò Ò ô Ô ǒ Ǒ ɔ Ɔ p P r R s S t T u U ú Ú ù Ù û Û ǔ Ǔ ũ Ũ ṹ Ṹ v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̂ ◌̌ ◌̃ ◌̃ ◌̀"
+  auxiliary: "f F q Q x X"
+}

--- a/Lib/gflanguages/data/languages/mzw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mzw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "mzw_Latn"
+language: "mzw"
+script: "Latn"
+name: "Deg"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/nat_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nat_Latn.textproto
@@ -1,0 +1,9 @@
+id: "nat_Latn"
+language: "nat"
+script: "Latn"
+name: "Cahungwarya"
+exemplar_chars {
+  base: "a A b B c C d D e E g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y z Z"
+  marks: "◌̱"
+  auxiliary: "f F q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/naw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/naw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "naw_Latn"
+language: "naw"
+script: "Latn"
+name: "Nawuri"
+exemplar_chars {
+  base: "a A á Á b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U w W y Y ŋ Ŋ ɔ Ɔ ɛ Ɛ ɩ Ɩ ʋ Ʋ"
+  marks: "◌́"
+}

--- a/Lib/gflanguages/data/languages/ncu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ncu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ncu_Latn"
+language: "ncu"
+script: "Latn"
+name: "Chumburung"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U w W y Y"
+  marks: "◌̱ ◌̀"
+  auxiliary: "c C j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ndj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ndj_Latn.textproto
@@ -1,0 +1,7 @@
+id: "ndj_Latn"
+language: "ndj"
+script: "Latn"
+name: "Ndamba"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/ndz_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ndz_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ndz_Latn"
+language: "ndz"
+script: "Latn"
+name: "Ndogo"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G i I j J k K l L m M n N o O p P r R ṛ Ṛ s S t T u U v V w W y Y z Z ŋ Ŋ ꞌ Ꞌ"
+  marks: "◌̣ ◌̀ ◌́ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/neb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/neb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "neb_Latn"
+language: "neb"
+script: "Latn"
+name: "Toura"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G i I ɩ Ɩ k K l L o O ɔ Ɔ p P s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "c C j J m M q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/nfr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nfr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nfr_Latn"
+language: "nfr"
+script: "Latn"
+name: "Nafaanra"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nga_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nga_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nga_Latn"
+language: "nga"
+script: "Latn"
+name: "Ngbaka"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I k K l L m M n N o O ɔ Ɔ p P s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/ngb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ngb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ngb_Latn"
+language: "ngb"
+script: "Latn"
+name: "Ngbandi, Northern"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I k K l L m M n N o O ɔ Ɔ p P s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/ngp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ngp_Latn.textproto
@@ -1,0 +1,7 @@
+id: "ngp_Latn"
+language: "ngp"
+script: "Latn"
+name: "Ngulu"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/nhb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nhb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nhb_Latn"
+language: "nhb"
+script: "Latn"
+name: "Beng"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nhu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nhu_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nhu_Latn"
+language: "nhu"
+script: "Latn"
+name: "Noone"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y ŋ Ŋ ɛ Ɛ"
+  marks: "◌̀ ◌́ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/nin_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nin_Latn.textproto
@@ -1,0 +1,9 @@
+id: "nin_Latn"
+language: "nin"
+script: "Latn"
+name: "Ninzo"
+exemplar_chars {
+  base: "a A á Á ā Ā à À â Â ǎ Ǎ b B ɓ Ɓ c C d D e E é É ē Ē è È ê Ê ě Ě f F g G h H i I í Í ī Ī ì Ì î Î ǐ Ǐ ɨ Ɨ j J k K ƙ Ƙ l L m M n N o O ó Ó ō Ō ò Ò ô Ô ǒ Ǒ p P q Q r R s S t T u U ú Ú ū Ū ù Ù û Û ǔ Ǔ v V w W y Y z Z"
+  marks: "◌́ ◌̄ ◌̀ ◌̂ ◌̌ ◌̱ ◌̀ ◌̂ ◌̄"
+  auxiliary: "x X"
+}

--- a/Lib/gflanguages/data/languages/niy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/niy_Latn.textproto
@@ -1,0 +1,9 @@
+id: "niy_Latn"
+language: "niy"
+script: "Latn"
+name: "Ngiti"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I ɨ Ɨ k K l L m M n N o O ɔ Ɔ p P r R s S t T u U ʉ Ʉ v V w W y Y z Z"
+  marks: "◌̀ ◌́ ◌̌"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nko_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nko_Latn.textproto
@@ -1,0 +1,9 @@
+id: "nko_Latn"
+language: "nko"
+script: "Latn"
+name: "Nkonya"
+exemplar_chars {
+  base: "a A á Á b B d D e E é É ɛ Ɛ f F g G h H i I í Í ɩ Ɩ k K l L m M n N ŋ Ŋ o O ó Ó ɔ Ɔ p P r R s S t T u U ú Ú ʋ Ʋ v V w W y Y z Z"
+  marks: "◌́"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nmz_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nmz_Latn.textproto
@@ -1,0 +1,9 @@
+id: "nmz_Latn"
+language: "nmz"
+script: "Latn"
+name: "Nawdm"
+exemplar_chars {
+  base: "a A à À á Á b B d D e E ɛ Ɛ f F g G h H ɦ Ɦ i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ r R s S t T u U v V w W y Y"
+  marks: "◌̀ ◌́ ◌̈"
+  auxiliary: "c C p P q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/nnq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nnq_Latn.textproto
@@ -1,0 +1,7 @@
+id: "nnq_Latn"
+language: "nnq"
+script: "Latn"
+name: "Ngindo"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/nnw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nnw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nnw_Latn"
+language: "nnw"
+script: "Latn"
+name: "Nuni, Southern"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ə Ə ɛ Ɛ ɩ Ɩ ʋ Ʋ"
+  marks: "◌̀ ◌́"
+}

--- a/Lib/gflanguages/data/languages/nrb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nrb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nrb_Latn"
+language: "nrb"
+script: "Latn"
+name: "Nara"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O r R s S t T u U v V w W y Y"
+  auxiliary: "c C p P q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ntm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ntm_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ntm_Latn"
+language: "ntm"
+script: "Latn"
+name: "Nateni"
+exemplar_chars {
+  base: "á Á b B c C d D e E è È é É ɛ Ɛ f F h H i I ì Ì í Í ḭ Ḭ k K m M n N ǹ Ǹ ń Ń o O ò Ò ó Ó ɔ Ɔ p P s S t T u U ù Ù ú Ú ṵ Ṵ w W y Y"
+  marks: "◌́ ◌̰ ◌̀"
+  auxiliary: "l L q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/ntr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ntr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ntr_Latn"
+language: "ntr"
+script: "Latn"
+name: "Delo"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I k K l L m M n N ŋ Ŋ x X o O ɔ Ɔ p P r R s S t T u U w W y Y"
+  auxiliary: "c C j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/nui_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nui_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nui_Latn"
+language: "nui"
+script: "Latn"
+name: "Kombe"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C j J q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nup_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nup_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nup_Latn"
+language: "nup"
+script: "Latn"
+name: "Nupe-Nupe-Tako"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nuv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nuv_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nuv_Latn"
+language: "nuv"
+script: "Latn"
+name: "Nuni, Northern"
+exemplar_chars {
+  base: "a A b B c C d D e E ə Ə ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/nwb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nwb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "nwb_Latn"
+language: "nwb"
+script: "Latn"
+name: "Nyabwa"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G i I ɩ Ɩ j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ogc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ogc_Latn.textproto
@@ -1,0 +1,9 @@
+id: "ogc_Latn"
+language: "ogc"
+script: "Latn"
+name: "Ogbah"
+exemplar_chars {
+  base: "a A á Á à À b B c C d D é É è È f F g G h H i I í Í ì Ì j J k K l L m M n N o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌́ ◌̀"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/okr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/okr_Latn.textproto
@@ -1,0 +1,9 @@
+id: "okr_Latn"
+language: "okr"
+script: "Latn"
+name: "Kirike"
+exemplar_chars {
+  base: "a A b B ḅ Ḅ d D ḍ Ḍ e E ẹ Ẹ f F g G h H i I ị Ị j J k K l L m M n N o O ọ Ọ p P r R s S t T u U ụ Ụ v V w W y Y z Z"
+  marks: "◌̣"
+  auxiliary: "c C q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ozm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ozm_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ozm_Latn"
+language: "ozm"
+script: "Latn"
+name: "Koonzime"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I ɨ Ɨ j J k K l L m M n N ŋ Ŋ o O ø Ø ɔ Ɔ œ Œ p P r R s S t T u U ʉ Ʉ v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/pbi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/pbi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "pbi_Latn"
+language: "pbi"
+script: "Latn"
+name: "Parkwa"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ə Ə f F h H i I ɨ Ɨ j J k K l L m M n N ŋ Ŋ g G p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "o O q Q x X"
+}

--- a/Lib/gflanguages/data/languages/pil_Latn.textproto
+++ b/Lib/gflanguages/data/languages/pil_Latn.textproto
@@ -1,0 +1,8 @@
+id: "pil_Latn"
+language: "pil"
+script: "Latn"
+name: "Yom"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ ə Ə f F g G ɣ Ɣ h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʊ Ʊ v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/pip_Latn.textproto
+++ b/Lib/gflanguages/data/languages/pip_Latn.textproto
@@ -1,0 +1,7 @@
+id: "pip_Latn"
+language: "pip"
+script: "Latn"
+name: "Pero"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/png_Latn.textproto
+++ b/Lib/gflanguages/data/languages/png_Latn.textproto
@@ -1,0 +1,9 @@
+id: "png_Latn"
+language: "png"
+script: "Latn"
+name: "Pangu"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É f F g G h H i I í Í j J k K l L m M n N o O ó Ó p P r R s S t T u U ú Ú v V w W y Y z Z ꞌ Ꞌ"
+  marks: "◌́ ◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/poy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/poy_Latn.textproto
@@ -1,0 +1,7 @@
+id: "poy_Latn"
+language: "poy"
+script: "Latn"
+name: "Pogolo"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/pym_Latn.textproto
+++ b/Lib/gflanguages/data/languages/pym_Latn.textproto
@@ -1,0 +1,7 @@
+id: "pym_Latn"
+language: "pym"
+script: "Latn"
+name: "Pyam"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ə Ə f F g G h H ɦ Ɦ i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/rel_Latn.textproto
+++ b/Lib/gflanguages/data/languages/rel_Latn.textproto
@@ -1,0 +1,8 @@
+id: "rel_Latn"
+language: "rel"
+script: "Latn"
+name: "Rendille"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O r R s S t T u U w W y Y"
+  auxiliary: "c C p P q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/res_Latn.textproto
+++ b/Lib/gflanguages/data/languages/res_Latn.textproto
@@ -1,0 +1,9 @@
+id: "res_Latn"
+language: "res"
+script: "Latn"
+name: "Reshe"
+exemplar_chars {
+  base: "a A à À á Á b B c C d D e E è È é É g G h H i I j J k K l L m M n N o O p P r R s S t T u U w W y Y z Z"
+  marks: "◌̀ ◌́ ◌̱"
+  auxiliary: "f F q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/rub_Latn.textproto
+++ b/Lib/gflanguages/data/languages/rub_Latn.textproto
@@ -1,0 +1,8 @@
+id: "rub_Latn"
+language: "rub"
+script: "Latn"
+name: "Gungu"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ"
+  marks: "◌̯ ◌̱"
+}

--- a/Lib/gflanguages/data/languages/ruf_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ruf_Latn.textproto
@@ -1,0 +1,7 @@
+id: "ruf_Latn"
+language: "ruf"
+script: "Latn"
+name: "Luguru"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/sba_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sba_Latn.textproto
@@ -1,0 +1,8 @@
+id: "sba_Latn"
+language: "sba"
+script: "Latn"
+name: "Ngambay"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ g G h H i I j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  auxiliary: "c C f F q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/she_Latn.textproto
+++ b/Lib/gflanguages/data/languages/she_Latn.textproto
@@ -1,0 +1,7 @@
+id: "she_Latn"
+language: "she"
+script: "Latn"
+name: "Sheko"
+exemplar_chars {
+  base: "a A b B d D e E ə Ə f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/shu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/shu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "shu_Latn"
+language: "shu"
+script: "Latn"
+name: "Arabic, Chadian Spoken"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I j J k K l L m M n N o O r R s S t T u U w W y Y z Z"
+  marks: "◌̂ ◌̧ ◌́ ◌̀ ◌̈"
+  auxiliary: "â Â æ Æ c C ç Ç é É è È ê Ê ë Ë î Î ï Ï ô Ô œ Œ p P q Q ù Ù û Û ü Ü v V x X ÿ Ÿ"
+}

--- a/Lib/gflanguages/data/languages/sig_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sig_Latn.textproto
@@ -1,0 +1,8 @@
+id: "sig_Latn"
+language: "sig"
+script: "Latn"
+name: "Paasaal"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I ɩ Ɩ k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y"
+  auxiliary: "c C j J q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/sil_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sil_Latn.textproto
@@ -1,0 +1,8 @@
+id: "sil_Latn"
+language: "sil"
+script: "Latn"
+name: "Sisaala, Tumulung"
+exemplar_chars {
+  base: "a A b B d D ɛ Ɛ e E f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ ɔ Ɔ o O p P r R s S t T ʋ Ʋ u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/sld_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sld_Latn.textproto
@@ -1,0 +1,8 @@
+id: "sld_Latn"
+language: "sld"
+script: "Latn"
+name: "Sissala"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D e E ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/snw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/snw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "snw_Latn"
+language: "snw"
+script: "Latn"
+name: "Selee"
+exemplar_chars {
+  base: "a A à À ã Ã b B d D e E f F g G h H i I ĩ Ĩ k K l L m M n N o O p P r R s S t T u U ũ Ũ v V w W y Y ɔ Ɔ ɛ Ɛ"
+  marks: "◌̀ ◌̃ ◌́"
+}

--- a/Lib/gflanguages/data/languages/sok_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sok_Latn.textproto
@@ -1,0 +1,9 @@
+id: "sok_Latn"
+language: "sok"
+script: "Latn"
+name: "Sokoro"
+exemplar_chars {
+  base: "a A á Á b B ɓ Ɓ c C d D ɗ Ɗ e E ɛ Ɛ ə Ə g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U w W y Y ƴ Ƴ"
+  marks: "◌́ ◌̰"
+  auxiliary: "f F q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/soy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/soy_Latn.textproto
@@ -1,0 +1,9 @@
+id: "soy_Latn"
+language: "soy"
+script: "Latn"
+name: "Miyobe"
+exemplar_chars {
+  base: "a A á Á c C e E é É ẽ Ẽ ɛ Ɛ f F h H i I í Í ĩ Ĩ k K l L m M n N ŋ Ŋ o O ó Ó õ Õ ṍ Ṍ ɔ Ɔ p P r R s S t T u U ú Ú ũ Ũ ṹ Ṹ w W y Y"
+  marks: "◌́ ◌̃"
+  auxiliary: "b B d D g G j J q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/spp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/spp_Latn.textproto
@@ -1,0 +1,8 @@
+id: "spp_Latn"
+language: "spp"
+script: "Latn"
+name: "Sénoufo, Supyire"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ɛ Ɛ ɲ Ɲ"
+  marks: "◌̀ ◌́ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/suq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/suq_Latn.textproto
@@ -1,0 +1,8 @@
+id: "suq_Latn"
+language: "suq"
+script: "Latn"
+name: "Suri, Tirmaga-Chai"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ g G h H i I j J k K l L m M n N o O ɔ Ɔ r R s S t T u U w W y Y z Z"
+  auxiliary: "f F p P q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/sur_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sur_Latn.textproto
@@ -1,0 +1,9 @@
+id: "sur_Latn"
+language: "sur"
+script: "Latn"
+name: "Mwaghavul"
+exemplar_chars {
+  base: "a A à À á Á b B ɓ Ɓ c C d D ɗ Ɗ e E è È é É f F g G h H i I ì Ì í Í ɨ Ɨ j J k K l L m M n N o O ó Ó ò Ò p P r R s S t T u U ú Ú ù Ù v V w W y Y z Z"
+  marks: "◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/swc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/swc_Latn.textproto
@@ -1,0 +1,8 @@
+id: "swc_Latn"
+language: "swc"
+script: "Latn"
+name: "Swahili, Congo"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/sxb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sxb_Latn.textproto
@@ -1,0 +1,7 @@
+id: "sxb_Latn"
+language: "sxb"
+script: "Latn"
+name: "Suba"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/sxw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sxw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "sxw_Latn"
+language: "sxw"
+script: "Latn"
+name: "Gbe, Saxwe"
+exemplar_chars {
+  base: "a A b B c C d D ɖ Ɖ e E ɛ Ɛ f F g G ɣ Ɣ h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/tal_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tal_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tal_Latn"
+language: "tal"
+script: "Latn"
+name: "Tal"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ e E f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C q Q x X"
+}

--- a/Lib/gflanguages/data/languages/tan_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tan_Latn.textproto
@@ -1,0 +1,9 @@
+id: "tan_Latn"
+language: "tan"
+script: "Latn"
+name: "Tangale"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ e E ẹ Ẹ g G h H i I ị Ị j J k K ƙ Ƙ l L m M n N ṇ Ṇ o O ọ Ọ p P r R s S t T u U ụ Ụ w W y Y z Z"
+  marks: "◌̣"
+  auxiliary: "c C f F q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/ted_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ted_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ted_Latn"
+language: "ted"
+script: "Latn"
+name: "Krumen, Tepo"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I ɩ Ɩ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ w W y Y"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/tfi_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tfi_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tfi_Latn"
+language: "tfi"
+script: "Latn"
+name: "Gbe, Tofin"
+exemplar_chars {
+  base: "a A b B c C d D ɖ Ɖ e E ɛ Ɛ f F g G h H i I j J k K l L m M n N o O ɔ Ɔ p P s S t T u U w W x X y Y z Z"
+  auxiliary: "q Q r R v V"
+}

--- a/Lib/gflanguages/data/languages/tik_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tik_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tik_Latn"
+language: "tik"
+script: "Latn"
+name: "Tikar"
+exemplar_chars {
+  base: "a A æ Æ b B ɓ Ɓ c C d D ɗ Ɗ e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q r R x X"
+}

--- a/Lib/gflanguages/data/languages/tke_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tke_Latn.textproto
@@ -1,0 +1,7 @@
+id: "tke_Latn"
+language: "tke"
+script: "Latn"
+name: "Takwane"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/tlj_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tlj_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tlj_Latn"
+language: "tlj"
+script: "Latn"
+name: "Talinga-Bwisi"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y"
+  marks: "◌̱"
+}

--- a/Lib/gflanguages/data/languages/tod_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tod_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tod_Latn"
+language: "tod"
+script: "Latn"
+name: "Toma"
+exemplar_chars {
+  base: "a A á Á b B d D e E é É f F g G i I k K l L m M n N o O p P s S t T u U v V w W y Y z Z ɓ Ɓ ɔ Ɔ ɗ Ɗ ɛ Ɛ ɠ Ɠ ɲ Ɲ ʋ Ʋ"
+  marks: "◌́ ◌̀"
+}

--- a/Lib/gflanguages/data/languages/toq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/toq_Latn.textproto
@@ -1,0 +1,9 @@
+id: "toq_Latn"
+language: "toq"
+script: "Latn"
+name: "Toposa"
+exemplar_chars {
+  base: "a A b B c C d D e E g G i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U w W y Y"
+  marks: "◌̠"
+  auxiliary: "f F h H q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/tpm_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tpm_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tpm_Latn"
+language: "tpm"
+script: "Latn"
+name: "Tampulma"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɔ Ɔ ɛ Ɛ"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/tsw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tsw_Latn.textproto
@@ -1,0 +1,9 @@
+id: "tsw_Latn"
+language: "tsw"
+script: "Latn"
+name: "Tsishingini"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ɓ Ɓ ɗ Ɗ ꞌ Ꞌ"
+  marks: "◌̱"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/ttr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ttr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "ttr_Latn"
+language: "ttr"
+script: "Latn"
+name: "Tera"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/tul_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tul_Latn.textproto
@@ -1,0 +1,8 @@
+id: "tul_Latn"
+language: "tul"
+script: "Latn"
+name: "Tula"
+exemplar_chars {
+  base: "a A b B c C d D e E f F h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "g G q Q x X"
+}

--- a/Lib/gflanguages/data/languages/tuq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tuq_Latn.textproto
@@ -1,0 +1,9 @@
+id: "tuq_Latn"
+language: "tuq"
+script: "Latn"
+name: "Tedaga"
+exemplar_chars {
+  base: "a A b B c C d D e E ẹ Ẹ ɛ Ɛ ə Ə f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ọ Ọ ɔ Ɔ p P r R s S š Š t T u U v V w W y Y z Z"
+  marks: "◌̣ ◌̌"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/tvd_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tvd_Latn.textproto
@@ -1,0 +1,9 @@
+id: "tvd_Latn"
+language: "tvd"
+script: "Latn"
+name: "Tsuvadi"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É f F g G h H i I í Í j J k K l L m M n N ñ Ñ o O ó Ó p P r R s S t T u U ú Ú v V w W y Y z Z"
+  marks: "◌́ ◌̃"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/tvu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/tvu_Latn.textproto
@@ -1,0 +1,9 @@
+id: "tvu_Latn"
+language: "tvu"
+script: "Latn"
+name: "Tunen"
+exemplar_chars {
+  base: "a A á Á b B c C e E é É ɛ Ɛ f F h H i I í Í k K l L m M n N ŋ Ŋ o O ó Ó ɔ Ɔ s S t T u U ú Ú w W y Y"
+  marks: "◌́"
+  auxiliary: "d D g G j J p P q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/uth_Latn.textproto
+++ b/Lib/gflanguages/data/languages/uth_Latn.textproto
@@ -1,0 +1,9 @@
+id: "uth_Latn"
+language: "uth"
+script: "Latn"
+name: "ut-Hun"
+exemplar_chars {
+  base: "ɑ Ɑ a A à À á Á b B c C d D e E è È é É f F g G h H i I ì Ì í Í j J k K l L m M n N o O ò Ò ó Ó p P r R s S t T u U ù Ù ú Ú v V w W y Y z Z"
+  marks: "◌̀ ◌́"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/utr_Latn.textproto
+++ b/Lib/gflanguages/data/languages/utr_Latn.textproto
@@ -1,0 +1,8 @@
+id: "utr_Latn"
+language: "utr"
+script: "Latn"
+name: "Etulo"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I k K l L m M n N o O ɔ Ɔ p P r R s S t T u U v V w W x X y Y z Z"
+  auxiliary: "j J q Q"
+}

--- a/Lib/gflanguages/data/languages/vag_Latn.textproto
+++ b/Lib/gflanguages/data/languages/vag_Latn.textproto
@@ -1,0 +1,8 @@
+id: "vag_Latn"
+language: "vag"
+script: "Latn"
+name: "Vagla"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/vid_Latn.textproto
+++ b/Lib/gflanguages/data/languages/vid_Latn.textproto
@@ -1,0 +1,7 @@
+id: "vid_Latn"
+language: "vid"
+script: "Latn"
+name: "Vidunda"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/vut_Latn.textproto
+++ b/Lib/gflanguages/data/languages/vut_Latn.textproto
@@ -1,0 +1,8 @@
+id: "vut_Latn"
+language: "vut"
+script: "Latn"
+name: "Vute"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E ə Ə f F g G h H i I ɨ Ɨ j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/wal_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wal_Latn.textproto
@@ -1,0 +1,7 @@
+id: "wal_Latn"
+language: "wal"
+script: "Latn"
+name: "Wolaytta"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/wan_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wan_Latn.textproto
@@ -1,0 +1,8 @@
+id: "wan_Latn"
+language: "wan"
+script: "Latn"
+name: "Wan"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/wci_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wci_Latn.textproto
@@ -1,0 +1,8 @@
+id: "wci_Latn"
+language: "wci"
+script: "Latn"
+name: "Gbe, Waci"
+exemplar_chars {
+  base: "a A b B c C d D ɖ Ɖ e E ɛ Ɛ f F ƒ Ƒ g G ɣ Ɣ h H x X i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P s S t T u U v V ʋ Ʋ w W y Y z Z"
+  auxiliary: "q Q r R"
+}

--- a/Lib/gflanguages/data/languages/wib_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wib_Latn.textproto
@@ -1,0 +1,9 @@
+id: "wib_Latn"
+language: "wib"
+script: "Latn"
+name: "Toussian, Southern"
+exemplar_chars {
+  base: "a A b B d D e E ɛ Ɛ f F h H i I ɩ Ɩ k K l L m M n N o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  marks: "◌̀ ◌́ ◌̂ ◌̃ ◌̌"
+  auxiliary: "c C j J q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/wja_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wja_Latn.textproto
@@ -1,0 +1,9 @@
+id: "wja_Latn"
+language: "wja"
+script: "Latn"
+name: "Waja"
+exemplar_chars {
+  base: "a A ā Ā ă Ă b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̄ ◌̆"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/wji_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wji_Latn.textproto
@@ -1,0 +1,8 @@
+id: "wji_Latn"
+language: "wji"
+script: "Latn"
+name: "Warji"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ c C d D ɗ Ɗ e E f F g G h H i I j J k K ƙ Ƙ l L m M n N o O p P r R s S t T u U w W y Y z Z"
+  auxiliary: "q Q v V x X"
+}

--- a/Lib/gflanguages/data/languages/wmw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wmw_Latn.textproto
@@ -1,0 +1,8 @@
+id: "wmw_Latn"
+language: "wmw"
+script: "Latn"
+name: "Mwani"
+exemplar_chars {
+  base: "a A ã Ã b B c C d D e E f F g G h H i I ĩ Ĩ j J k K l L m M n N o O p P r R s S t T u U ũ Ũ v V w W y Y z Z"
+  marks: "◌̃ ◌́ ◌̂"
+}

--- a/Lib/gflanguages/data/languages/wob_Latn.textproto
+++ b/Lib/gflanguages/data/languages/wob_Latn.textproto
@@ -1,0 +1,8 @@
+id: "wob_Latn"
+language: "wob"
+script: "Latn"
+name: "Wè Northern"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F i I ɩ Ɩ j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ w W"
+  auxiliary: "h H q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/xed_Latn.textproto
+++ b/Lib/gflanguages/data/languages/xed_Latn.textproto
@@ -1,0 +1,8 @@
+id: "xed_Latn"
+language: "xed"
+script: "Latn"
+name: "Hdi"
+exemplar_chars {
+  base: "a A á Á b B d D e E f F g G h H i I í Í k K l L m M n N p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ɓ Ɓ ɗ Ɗ ə Ə"
+  marks: "◌́"
+}

--- a/Lib/gflanguages/data/languages/xon_Latn.textproto
+++ b/Lib/gflanguages/data/languages/xon_Latn.textproto
@@ -1,0 +1,8 @@
+id: "xon_Latn"
+language: "xon"
+script: "Latn"
+name: "Konkomba"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N ŋ Ŋ o O v V ɔ Ɔ p P r R s S t T u U w W y Y"
+  auxiliary: "q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/xrb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/xrb_Latn.textproto
@@ -1,0 +1,8 @@
+id: "xrb_Latn"
+language: "xrb"
+script: "Latn"
+name: "Karaboro, Eastern"
+exemplar_chars {
+  base: "a A b B c C d D e E ɛ Ɛ f F g G h H i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y"
+  auxiliary: "q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/xuo_Latn.textproto
+++ b/Lib/gflanguages/data/languages/xuo_Latn.textproto
@@ -1,0 +1,8 @@
+id: "xuo_Latn"
+language: "xuo"
+script: "Latn"
+name: "Kuo"
+exemplar_chars {
+  base: "a A à À b B d D e E f F g G h H i I ì Ì k K l L m M n N o O p P r R s S t T u U ù Ù v V w W y Y z Z ŋ Ŋ ɓ Ɓ ɔ Ɔ ɗ Ɗ ɛ Ɛ"
+  marks: "◌̀ ◌́ ◌̌ ◌̰"
+}

--- a/Lib/gflanguages/data/languages/xwe_Latn.textproto
+++ b/Lib/gflanguages/data/languages/xwe_Latn.textproto
@@ -1,0 +1,8 @@
+id: "xwe_Latn"
+language: "xwe"
+script: "Latn"
+name: "Gbe, Xwela"
+exemplar_chars {
+  base: "a A b B c C d D ɖ Ɖ e E ɛ Ɛ f F g G ɣ Ɣ h H x X i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "q Q"
+}

--- a/Lib/gflanguages/data/languages/yal_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yal_Latn.textproto
@@ -1,0 +1,7 @@
+id: "yal_Latn"
+language: "yal"
+script: "Latn"
+name: "Yalunka"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U w W x X y Y ɔ Ɔ ɛ Ɛ ɲ Ɲ"
+}

--- a/Lib/gflanguages/data/languages/yam_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yam_Latn.textproto
@@ -1,0 +1,8 @@
+id: "yam_Latn"
+language: "yam"
+script: "Latn"
+name: "Yamba"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y z Z ŋ Ŋ ə Ə ɛ Ɛ ʉ Ʉ"
+  marks: "◌̀"
+}

--- a/Lib/gflanguages/data/languages/yas_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yas_Latn.textproto
@@ -1,0 +1,9 @@
+id: "yas_Latn"
+language: "yas"
+script: "Latn"
+name: "Nugunu"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ɛ Ɛ f F g G h H i I í Í k K l L m M n N ŋ Ŋ o O ó Ó ɔ Ɔ p P s S t T u U ú Ú y Y"
+  marks: "◌́"
+  auxiliary: "j J q Q r R v V w W x X"
+}

--- a/Lib/gflanguages/data/languages/yat_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yat_Latn.textproto
@@ -1,0 +1,9 @@
+id: "yat_Latn"
+language: "yat"
+script: "Latn"
+name: "Yambeta"
+exemplar_chars {
+  base: "a A á Á b B c C d D e E é É ɛ Ɛ ə Ə f F g G i I í Í j J k K l L m M n N ŋ Ŋ o O ó Ó ɔ Ɔ p P s S t T u U ú Ú w W y Y"
+  marks: "◌́"
+  auxiliary: "h H q Q r R v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/yay_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yay_Latn.textproto
@@ -1,0 +1,9 @@
+id: "yay_Latn"
+language: "yay"
+script: "Latn"
+name: "Agwagwune"
+exemplar_chars {
+  base: "a A b B ɓ Ɓ d D ɗ Ɗ e E ẹ Ẹ g G h H i I j J k K l L m M n N o O ọ Ọ p P r R s S t T u U w W y Y"
+  marks: "◌̣"
+  auxiliary: "c C f F q Q v V x X z Z"
+}

--- a/Lib/gflanguages/data/languages/yaz_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yaz_Latn.textproto
@@ -1,0 +1,9 @@
+id: "yaz_Latn"
+language: "yaz"
+script: "Latn"
+name: "Lokaa"
+exemplar_chars {
+  base: "a A à À ạ Ạ b B c C d D e E ẹ Ẹ f F g G h H i I ì Ì j J k K l L m M n N o O ò Ò ọ Ọ p P r R s S t T u U v V w W y Y z Z"
+  marks: "◌̀ ◌̣"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/yba_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yba_Latn.textproto
@@ -1,0 +1,9 @@
+id: "yba_Latn"
+language: "yba"
+script: "Latn"
+name: "Yala"
+exemplar_chars {
+  base: "a A ā Ā b B c C d D e E ē Ē ɛ Ɛ f F g G h H i I ī Ī j J k K l L m M n N o O ō Ō ɔ Ɔ p P r R s S t T u U ū Ū v V w W y Y z Z"
+  marks: "◌̄ ◌̍"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/yer_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yer_Latn.textproto
@@ -1,0 +1,9 @@
+id: "yer_Latn"
+language: "yer"
+script: "Latn"
+name: "Tarok"
+exemplar_chars {
+  base: "á Á à À â Â a A b B ɓ Ɓ c C d D ɗ Ɗ e E é É è È ê Ê ə Ə f F g G h H i I í Í ì Ì î Î j J k K l L m M ḿ Ḿ n N ń Ń ǹ Ǹ ñ Ñ o O ó Ó ò Ò ô Ô p P r R s S t T u U ú Ú ù Ù û Û v V w W y Y z Z"
+  marks: "◌́ ◌̀ ◌̂ ◌̱ ◌̃"
+  auxiliary: "q Q x X"
+}

--- a/Lib/gflanguages/data/languages/yko_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yko_Latn.textproto
@@ -1,0 +1,8 @@
+id: "yko_Latn"
+language: "yko"
+script: "Latn"
+name: "Yasa"
+exemplar_chars {
+  base: "a A b B d D e E f F g G h H i I k K l L m M n N o O p P r R s S t T u U v V w W y Y"
+  auxiliary: "c C j J q Q x X z Z"
+}

--- a/Lib/gflanguages/data/languages/yre_Latn.textproto
+++ b/Lib/gflanguages/data/languages/yre_Latn.textproto
@@ -1,0 +1,8 @@
+id: "yre_Latn"
+language: "yre"
+script: "Latn"
+name: "Yaouré"
+exemplar_chars {
+  base: "c C d D e E ɛ Ɛ f F g G i I ɩ Ɩ j J k K l L m M n N o O ɔ Ɔ p P r R s S t T u U ʋ Ʋ v V w W y Y z Z"
+  auxiliary: "x X"
+}

--- a/Lib/gflanguages/data/languages/zay_Latn.textproto
+++ b/Lib/gflanguages/data/languages/zay_Latn.textproto
@@ -1,0 +1,7 @@
+id: "zay_Latn"
+language: "zay"
+script: "Latn"
+name: "Zayse"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/ziw_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ziw_Latn.textproto
@@ -1,0 +1,7 @@
+id: "ziw_Latn"
+language: "ziw"
+script: "Latn"
+name: "Zigula"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P s S t T u U v V w W y Y z Z"
+}

--- a/Lib/gflanguages/data/languages/zne_Latn.textproto
+++ b/Lib/gflanguages/data/languages/zne_Latn.textproto
@@ -1,0 +1,8 @@
+id: "zne_Latn"
+language: "zne"
+script: "Latn"
+name: "Zande"
+exemplar_chars {
+  base: "a A b B d D e E f F g G i I k K m M n N o O p P r R s S t T u U v V w W y Y z Z"
+  auxiliary: "c C h H j J l L q Q x X"
+}

--- a/Lib/gflanguages/data/languages/zul_Latn.textproto
+++ b/Lib/gflanguages/data/languages/zul_Latn.textproto
@@ -1,0 +1,9 @@
+id: "zul_Latn"
+language: "zul"
+script: "Latn"
+name: "Zulu"
+exemplar_chars {
+  base: "a A b B c C d D e E f F g G h H i I j J k K l L m M n N o O p P q Q r R s S t T u U v V w W x X y Y z Z"
+  marks: "◌́ ◌̀ ◌̆ ◌̂ ◌̊ ◌̈ ◌̃ ◌̄ ◌̧"
+  auxiliary: "á Á à À ă Ă â Â å Å ä Ä ã Ã ā Ā æ Æ ç Ç é É è È ĕ Ĕ ê Ê ë Ë ē Ē í Í ì Ì ĭ Ĭ î Î ï Ï ī Ī ñ Ñ ó Ó ò Ò ŏ Ŏ ô Ô ö Ö ø Ø ō Ō œ Œ ú Ú ù Ù ŭ Ŭ û Û ü Ü ū Ū ÿ Ÿ"
+}


### PR DESCRIPTION
Additional 313 exemplar character sets have been added to support Latin-based African languages. This is commit is a precursor to performing shaperglot analysis of the GF library and Google Sans.

Data is sourced from ScriptSource which has been reorganized and modified to include uppercase letters and isolate marks. Of the 1913 African language tags with no exemplar char data in gflang the these are the only ones with data on ScriptSource.