### PR TITLE
West Frisian [fy]: remove {ij} and {íj́} from base

### DIFF
--- a/Lib/gflanguages/data/languages/fy_Latn.textproto
+++ b/Lib/gflanguages/data/languages/fy_Latn.textproto
@@ -6,7 +6,7 @@ autonym: "Frysk"
 population: 743057
 region: "NL"
 exemplar_chars {
-  base: "a á à â ä b c d e é è ê ë f g h i í ï {ij} {íj́} j k l m n o ó ô ö p r s t u ú û ü v w y ý z"
+  base: "a á à â ä b c d e é è ê ë f g h i í ï y ý j k l m n o ó ô ö p r s t u ú û ü v w z"
   auxiliary: "æ ò ù"
   marks: "◌́ ◌̂ ◌̈"
   numerals: "- ‑ , . % ‰ + 0 1 2 3 4 5 6 7 8 9"


### PR DESCRIPTION
See https://unicode-org.atlassian.net/browse/CLDR-16114