### PR TITLE
hu_Latn: remove ⟨ and ⟩, not used in normal text

### DIFF
--- a/Lib/gflanguages/data/languages/hu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/hu_Latn.textproto
@@ -17,7 +17,7 @@ exemplar_chars {
   auxiliary: "à ă â å ä ã ā æ ç è ĕ ê ë ē ì ĭ î ï ī ñ ò ŏ ô ø ō œ q ù ŭ û ū w x y ÿ"
   marks: "◌́ ◌̈ ◌̋"
   numerals: "  - ‑ , % ‰ + 0 1 2 3 4 5 6 7 8 9"
-  punctuation: "- ‑ – , ; : ! ? . … \' ’ \" ” „ « » ( ) [ ] { } ⟨ ⟩ § @ * / & # ~ ⁒"
+  punctuation: "- ‑ – , ; : ! ? . … \' ’ \" ” „ « » ( ) [ ] { } § @ * / & # ~ ⁒"
   index: "A Á B C {CS} D {DZ} {DZS} E É F G {GY} H I Í J K L {LY} M N {NY} O Ó Ö Ő P Q R S {SZ} T {TY} U Ú Ü Ű V W X Y Z {ZS}"
 }
 sample_text {


### PR DESCRIPTION
⟨ and ⟩ are used when describing orthography or graphemes, like in linguistic texts, or in mathematical notation. They are not used in normal text. They belong in mathematic or scientific notation sets.