### PR TITLE
remove comma turned above from lv ltg and prg 

### DIFF
--- a/Lib/gflanguages/data/languages/ltg_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ltg_Latn.textproto
@@ -8,5 +8,5 @@ region: "LV"
 exemplar_chars {
   base: "A Ā B C Č D E Ē F G Ģ H I Ī J K Ķ L Ļ M N Ņ O Ō P R S Š T U Ū V Y Z Ž a ā b c č d e ē f g ģ h i ī j k ķ l ļ m n ņ o ō p r s š t u ū v y z ž"
   auxiliary: "Q W X q w x"
-  marks: "◌̄ ◌̌ ◌̧ ◌ ̒"
+  marks: "◌̄ ◌̌ ◌̧"
 }

--- a/Lib/gflanguages/data/languages/lv_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lv_Latn.textproto
@@ -8,7 +8,7 @@ region: "LV"
 exemplar_chars {
   base: "a ā b c č d e ē f g ģ h i ī j k ķ l ļ m n ņ o p r s š t u ū v z ž"
   auxiliary: "y ō q ŗ w x"
-  marks: "◌̄ ◌̌ ◌̧ ◌ ̒"
+  marks: "◌̄ ◌̌ ◌̧"
   numerals: "- , % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – — , ; : ! ? . … \' ‘ ’ ‚ \" “ ” „ ( ) [ ] @ * / & #"
   index: "A Ā B C Č D E Ē F G Ģ H I Ī Y J K Ķ L Ļ M N Ņ O P Q R S Š T U Ū V W X Z Ž"

--- a/Lib/gflanguages/data/languages/prg_Latn.textproto
+++ b/Lib/gflanguages/data/languages/prg_Latn.textproto
@@ -6,6 +6,6 @@ autonym: "Prūsiskan"
 population: 0
 exemplar_chars {
   base: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Ā Ē Ģ Ī Ķ Ņ Ō Ŗ Š Ū Ž Ț Ḑ a b c d e f g h i j k l m n o p q r s t u v w x y z ā ē ģ ī ķ ņ ō ŗ š ū ž ț ḑ"
-  marks: "◌̄ ◌̌ ◌̦ ◌̧ ◌ ̒"
+  marks: "◌̄ ◌̌ ◌̦ ◌̧"
 }
 historical: true


### PR DESCRIPTION
fixes #92

It means that `g comma turned above` will be required in GF_Latin_Core, but not `comma turned above comb`.