### PR TITLE
Update number of Sicilian speakers based on UNESCO stats

### DIFF
--- a/Lib/gflanguages/data/languages/scn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/scn_Latn.textproto
@@ -3,7 +3,7 @@ language: "scn"
 script: "Latn"
 name: "Sicilian"
 autonym: "Sicilianu"
-population: 511702
+population: 9999999
 region: "IT"
 exemplar_chars {
   base: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z À Â È Ì Ò Ù a b c d e f g h i j k l m n o p q r s t u v w x y z à â è ì ò ù"


### PR DESCRIPTION
Source: UNESCO World Atlas of Languages at:
https://en.wal.unesco.org/languages/sicilian