### PR TITLE
scn_Latn: likely closer to 4.7M speakers

### DIFF
--- a/Lib/gflanguages/data/languages/scn_Latn.textproto
+++ b/Lib/gflanguages/data/languages/scn_Latn.textproto
@@ -3,7 +3,7 @@ language: "scn"
 script: "Latn"
 name: "Sicilian"
 autonym: "Sicilianu"
-population: 9999999
+population: 4700000
 region: "IT"
 exemplar_chars {
   base: "A B C D Ḍ E F G H I J K L M N O P Q R S T U V W X Y Z À Â È Ê Ì Î Ò Ô Ù Û a b c d ḍ e f g h i j k l m n o p q r s t u v w x y z à â è ê ì î ò ô ù û"


### PR DESCRIPTION
English Wikipedia, based on Ethnologue 18, indicates 4.7M (2002). Note that Sicily has 4.8M speakers.

/cc @gino-m 
https://en.wal.unesco.org/languages/sicilian gives a range 1_000_000 to 9_999_999. Ethnologue 26 gives a range 1_000_000 to 1_000_000_000. Neither seems adequate.