### PR TITLE
Remove preferred name for modern Greek

### DIFF
--- a/Lib/gflanguages/data/languages/el_Grek.textproto
+++ b/Lib/gflanguages/data/languages/el_Grek.textproto
@@ -2,7 +2,6 @@ id: "el_Grek"
 language: "el"
 script: "Grek"
 name: "Greek"
-preferred_name: "Modern Greek"
 autonym: "Ελληνικά"
 population: 12384861
 region: "AL"


### PR DESCRIPTION
As per https://github.com/google/fonts/issues/6906, having a preferred name of "Modern Greek" hides the "Greek" language in an unexpected place.