### PR TITLE
Glyphs in lang defs

### DIFF
--- a/Lib/gflanguages/data/languages/ca_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ca_Latn.textproto
@@ -16,6 +16,9 @@ exemplar_chars {
   punctuation: "- – — , ; : ! ¡ ? ¿ . … \' ‘ ’ \" “ ” « » ( ) [ ] @ * / \\ & #"
   index: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z"
 }
+unencoded_glyphs {
+  glyphs: "periodcentered.loclCAT periodcentered.loclCAT.case"
+}
 sample_text {
   masthead_full: "TtOo"
   masthead_partial: "Ss"

--- a/Lib/gflanguages/data/languages/cs_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cs_Latn.textproto
@@ -14,6 +14,9 @@ exemplar_chars {
   punctuation: "- – , ; : ! ? . … ‘ ‚ “ „ ( ) [ ] @ * / &"
   index: "A B C Č D E F G H {CH} I J K L M N O P Q R Ř S Š T U V W X Y Z Ž"
 }
+unencoded_glyphs {
+  glyphs: "caroncomb.alt"
+}
 sample_text {
   masthead_full: "VvŠš"
   masthead_partial: "Ii"

--- a/Lib/gflanguages/data/languages/sk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/sk_Latn.textproto
@@ -16,6 +16,9 @@ exemplar_chars {
   punctuation: "- – , ; : ! ? . … ‘ ‚ “ „ ( ) [ ] @ * / &"
   index: "A Ä B C Č D Ď E F G H {CH} I J K L Ľ M N O Ô P Q R S Š T Ť U V W X Y Z Ž"
 }
+unencoded_glyphs {
+  glyphs: "caroncomb.alt"
+}
 sample_text {
   masthead_full: "VvŠš"
   masthead_partial: "Ee"

--- a/Lib/gflanguages/languages_public.proto
+++ b/Lib/gflanguages/languages_public.proto
@@ -32,10 +32,11 @@ message LanguageProto {
   optional int32 population = 7;
   repeated string region = 8;
   optional ExemplarCharsProto exemplar_chars = 9;
-  optional SampleTextProto sample_text = 10;
-  optional bool historical = 11;
-  repeated string source = 12;
-  optional string note = 13;
+  optional UnencodedGlyphsProto unencoded_glyphs = 10;
+  optional SampleTextProto sample_text = 11;
+  optional bool historical = 12;
+  repeated string source = 13;
+  optional string note = 14;
 
   // Next = 12;
 }
@@ -50,6 +51,11 @@ message ExemplarCharsProto {
   optional string index = 6;
 
   // Next = 7;
+}
+
+// Space-separated lists of unencoded glyphs used in a given language
+message UnencodedGlyphsProto {
+  optional string glyphs = 1;
 }
 
 message SampleTextProto {

--- a/Lib/gflanguages/languages_public_pb2.py
+++ b/Lib/gflanguages/languages_public_pb2.py
@@ -316,7 +316,7 @@ _UNENCODEDGLYPHSPROTO = _descriptor.Descriptor(
   create_key=_descriptor._internal_create_key,
   fields=[
     _descriptor.FieldDescriptor(
-      name='glyphs', full_name='google.languages_public.UnencodedGlyphsProto.base', index=0,
+      name='glyphs', full_name='google.languages_public.UnencodedGlyphsProto.glyphs', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,

--- a/Lib/gflanguages/languages_public_pb2.py
+++ b/Lib/gflanguages/languages_public_pb2.py
@@ -189,29 +189,36 @@ _LANGUAGEPROTO = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='sample_text', full_name='google.languages_public.LanguageProto.sample_text', index=9,
+      name='unencoded_glyphs', full_name='google.languages_public.LanguageProto.unencoded_glyphs', index=9,
       number=10, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='historical', full_name='google.languages_public.LanguageProto.historical', index=10,
-      number=11, type=8, cpp_type=7, label=1,
+      name='sample_text', full_name='google.languages_public.LanguageProto.sample_text', index=10,
+      number=11, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='historical', full_name='google.languages_public.LanguageProto.historical', index=11,
+      number=12, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='source', full_name='google.languages_public.LanguageProto.source', index=11,
-      number=12, type=9, cpp_type=9, label=3,
+      name='source', full_name='google.languages_public.LanguageProto.source', index=12,
+      number=13, type=9, cpp_type=9, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
     _descriptor.FieldDescriptor(
-      name='note', full_name='google.languages_public.LanguageProto.note', index=12,
-      number=13, type=9, cpp_type=9, label=1,
+      name='note', full_name='google.languages_public.LanguageProto.note', index=13,
+      number=14, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -279,6 +286,38 @@ _EXEMPLARCHARSPROTO = _descriptor.Descriptor(
     _descriptor.FieldDescriptor(
       name='index', full_name='google.languages_public.ExemplarCharsProto.index', index=5,
       number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=b"".decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=512,
+  serialized_end=634,
+)
+
+
+_UNENCODEDGLYPHSPROTO = _descriptor.Descriptor(
+  name='UnencodedGlyphsProto',
+  full_name='google.languages_public.UnencodedGlyphsProto',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  create_key=_descriptor._internal_create_key,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='glyphs', full_name='google.languages_public.UnencodedGlyphsProto.base', index=0,
+      number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=b"".decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -416,11 +455,13 @@ _SAMPLETEXTPROTO = _descriptor.Descriptor(
 )
 
 _LANGUAGEPROTO.fields_by_name['exemplar_chars'].message_type = _EXEMPLARCHARSPROTO
+_LANGUAGEPROTO.fields_by_name['unencoded_glyphs'].message_type = _UNENCODEDGLYPHSPROTO
 _LANGUAGEPROTO.fields_by_name['sample_text'].message_type = _SAMPLETEXTPROTO
 DESCRIPTOR.message_types_by_name['RegionProto'] = _REGIONPROTO
 DESCRIPTOR.message_types_by_name['ScriptProto'] = _SCRIPTPROTO
 DESCRIPTOR.message_types_by_name['LanguageProto'] = _LANGUAGEPROTO
 DESCRIPTOR.message_types_by_name['ExemplarCharsProto'] = _EXEMPLARCHARSPROTO
+DESCRIPTOR.message_types_by_name['UnencodedGlyphsProto'] = _UNENCODEDGLYPHSPROTO
 DESCRIPTOR.message_types_by_name['SampleTextProto'] = _SAMPLETEXTPROTO
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -451,6 +492,13 @@ ExemplarCharsProto = _reflection.GeneratedProtocolMessageType('ExemplarCharsProt
   # @@protoc_insertion_point(class_scope:google.languages_public.ExemplarCharsProto)
   })
 _sym_db.RegisterMessage(ExemplarCharsProto)
+
+UnencodedGlyphsProto = _reflection.GeneratedProtocolMessageType('UnencodedGlyphsProto', (_message.Message,), {
+  'DESCRIPTOR' : _UNENCODEDGLYPHSPROTO,
+  '__module__' : 'languages_public_pb2'
+  # @@protoc_insertion_point(class_scope:google.languages_public.ExemplarCharsProto)
+  })
+_sym_db.RegisterMessage(UnencodedGlyphsProto)
 
 SampleTextProto = _reflection.GeneratedProtocolMessageType('SampleTextProto', (_message.Message,), {
   'DESCRIPTOR' : _SAMPLETEXTPROTO,


### PR DESCRIPTION
As discussed two weeks ago, here's a PR that allows for the definition of unencoded glyphs inside language definitions, to be used with the upcoming GF_Glyphset overhaul https://github.com/googlefonts/glyphsets/pull/109