### PR TITLE
Update african languages

### DIFF
--- a/Lib/gflanguages/data/languages/cic_Latn.textproto
+++ b/Lib/gflanguages/data/languages/cic_Latn.textproto
@@ -6,8 +6,8 @@ autonym: "Chikashshanompa\'"
 population: 0
 region: "US"
 exemplar_chars {
-  base: "a A b B c C f F g G h H i I k K l L m M n N o O p P s S t T w W y Y {a̠} {A̠} {i̠} {I̠} {o̠} {O̠} \'"
-  marks: "◌̠"
+  base: "a A b B c C f F g G h H i I k K l L m M n N o O p P s S t T w W y Y {a̱} {A̱} {i̱} {I̱} {o̱} {O̱} \'"
+  marks: "◌̱"
 }
 sample_text {
   masthead_full: "HhIi"

--- a/Lib/gflanguages/data/languages/ee_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ee_Latn.textproto
@@ -8,7 +8,7 @@ region: "GH"
 region: "TG"
 exemplar_chars {
   base: "a A á Á à À ã Ã b B d D ɖ Ɖ e E é É è È ẽ Ẽ ɛ Ɛ {ɛ́} {Ɛ́} {ɛ̀} {Ɛ̀} {ɛ̃} {Ɛ̃} f F ƒ Ƒ g G ɣ Ɣ h H x X i I í Í ì Ì ĩ Ĩ k K l L m M n N ŋ Ŋ o O ó Ó ò Ò õ Õ ɔ Ɔ {ɔ́} {Ɔ́} {ɔ̀} {Ɔ̀} {ɔ̃} {Ɔ̃} p P r R s S t T u U ú Ú ù Ù ũ Ũ v V ʋ Ʋ w W y Y z Z"
-  auxiliary: "ă Ă â Â å Å ä Ä ā Ā æ Æ c C ç Ç ĕ Ĕ ê Ê ë Ë ĭ Ĭ î Î ï Ï j J ñ Ñ ŏ Ŏ ô Ô ö Ö ø Ø œ Œ q Q ŭ Ŭ û Û ü Ü ÿ Ÿ"
+  auxiliary: "â Â æ Æ c C ç Ç ê Ê ë Ë î Î ï Ï j J ô Ô œ Œ q Q û Û ü Ü"
   marks: "◌̀ ◌́ ◌̃ ◌̂ ◌̄ ◌̆ ◌̈ ◌̊ ◌̧"
   numerals: "- , . % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – — , ; : ! ? . … \' ‘ ’ \" “ ” ( ) [ ] { } @ * / & #"

--- a/Lib/gflanguages/data/languages/ema_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ema_Latn.textproto
@@ -6,7 +6,7 @@ population: 314000
 region: "NG"
 exemplar_chars {
   base: "a A ã Ã b B d D e E {e̱} {E̱} {ẽ̱} {Ẽ̱} f F g G h H i I ĩ Ĩ j J k K l L m M n N o O {o̱} {O̱} {õ̱} {Õ̱} p P r R s S t T u U ũ Ũ v V w W y Y z Z"
-  marks: "◌̠"
+  marks: "◌̱"
   auxiliary: "c C q Q x X"
 }
 source: "Rhonda L. Hartell, Alphabets de langues africaines, Dakar, BREDA (UNESCO) and Summer Institute of Linguistics, 1993"

--- a/Lib/gflanguages/data/languages/har_Latn.textproto
+++ b/Lib/gflanguages/data/languages/har_Latn.textproto
@@ -1,0 +1,11 @@
+id: "har_Latn"
+language: "ha"
+script: "Latn"
+name: "Harari"
+population: 26000
+region: "ET"
+exemplar_chars {
+  base: "a A b B t T j J g G h H {kh} {KH} d D r R z Z {zh} {ZH} s S {sh} {SH} {ch} {CH} x X c C f F q Q k K {xh} {XH} l L m M n N {gn} {GN} w W y Y e E i I o O u U â Â ê Ê î Î ô Ô û Û"
+  auxiliary: "ṫ Ṫ {dh} {DH} ṡ Ṡ ḋ Ḋ ż Ż ȧ Ȧ {gh} {GH} ḣ Ḣ p P v V"
+}
+source: "Awustirâliya Sây Harari Afôcha Qurân Gêy, Harari harfi kitâb, Awustirâliya Sây Harari Afôcha (Australian Saay Harari Association), 2010"

--- a/Lib/gflanguages/data/languages/ig_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ig_Latn.textproto
@@ -7,7 +7,7 @@ population: 27823640
 region: "NG"
 exemplar_chars {
   base: "a A b B {ch} {CH} d D e E ẹ Ẹ f F g G {gb} {GB} {gh} {GH} {gw} {GW} h H i I ị Ị j J k K {kp} {KP} {kw} {KW} l L m M n N ṅ Ṅ {nw} {NW} {ny} {NY} o O ọ Ọ p P r R s S {sh} {SH} t T u U ụ Ụ v V w W y Y z Z"
-  auxiliary: "á Á à À ā Ā c C é É è È ē Ē í Í ì Ì ī Ī {ị́} {Ị́} {ị̀} {Ị̀} ḿ Ḿ {m̀} {M̀} ń Ń ǹ Ǹ ó Ó ò Ò ō Ō {ọ́} {Ọ́} {ọ̀} {Ọ̀} q Q ú Ú ù Ù ū Ū {ụ́} {Ụ́} {ụ̀} {Ụ̀} x X"
+  auxiliary: "á Á à À ā Ā c C é É è È ē Ē í Í ì Ì ī Ī {ị́} {Ị́} {ị̀} {Ị̀} ḿ Ḿ {m̀} {M̀} ń Ń ǹ Ǹ ó Ó ò Ò ō Ō {ọ́} {Ọ́} {ọ̀} {Ọ̀} q Q ú Ú ù Ù ū Ū {ụ́} {Ụ́} {ụ̀} {Ụ̀} x X ɛ Ɛ ɵ Ɵ ŋ Ŋ"
   marks: "◌̀ ◌́ ◌̄ ◌̇ ◌̣"
   punctuation: "- , ; : ! ? . ‘ ’ “ ” ( ) [ ] { }"
   index: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z"
@@ -26,5 +26,6 @@ sample_text {
   specimen_21: "Onye ọ bụla tozuru iwe ikike na ohere nile e wepụtara na Nkwuwapụta nke a , n\'enweghi ịkpa oke ọ bụla dị ka nke agbụrụ; ụcha akpụkpọ ahụ, ịbụ nwoke ma ọ bụ nwanyị, asụsụ, okpukpe chi, echiche banyere ọchịchị ma ọ bụ ihe ọzọ, obodo ma ọ bụ ọ n\'obodo akụ, ọnọdụ ọmụmụ ma ọ bụ ọnọdụ ọzọ.\nOnye ọ bụla nwere ikike inwe ndụ, ohere na nchedo nke onwe ya."
   specimen_16: "Ọ dịghị onye a ga-ejigide n\'ọnọdu ohu ma ọ bụ odibọ a ga-amachi ịkpa ma ọ bụ ire ohu n\'ụdị ọ bụla.\nỌ dịghị onye a ga-akwagide n\'oke ntaramahụhụ, ma ọ bụ na mmeso omume na ntaramahụhụ obi ọjọọ, obi tara mmiri ma ọ bụ nke naz-ewetu ugwu mmadụ.\nOnye ọ bụla nwere ikike nkwanyere ugwu dị ka mmadụ ebe ọ bụla n\'usoro iwu.\nMadụ nile ha otu n\'usoro iwu, tozukwa oke n\'enweghi ịkpa oke ọ bụla inweta nchedo nha anya n\'usoro iwu. Madụ nile tozukwara oke nchedo nha anya megide ụdị ịkpa oke ọ bụla mebiri Nkwuwapụta nke a ma megidekwa ikwanye mmadụ ọ bụla n\'ụdị ikpa oke a.\nOnye ọ bụla nwere ikike ikpe mmezi ga-enwe nkawado ọha na eze nke ndi ụlọ ikpe tozuru etozu nke obodo ma e nwee omume ndi megidere ikike ntọala nke e nyegasịrị ya site n\'usoro ọchịchị ma ọbụ iwu."
 }
+source: "Margaret Mackeson Green, A descriptive grammar of Igbo, Berlin: Adakemie-Verlag, 1963"
 source: "E. Nolue Emenanjo, F. C. Ogbalu, “Igbo Orthography”, Ayo Bamgbose, Orthographies of Nigerian Languages, Manual I, Lagos: Federal Ministry of Education, National Language Center, 1982"
 note: "1936-1961 orthography used ɛ ɔ ɵ ŋ c instead of ị o u n ch."

--- a/Lib/gflanguages/data/languages/kea_Latn.textproto
+++ b/Lib/gflanguages/data/languages/kea_Latn.textproto
@@ -7,7 +7,7 @@ population: 530762
 region: "CV"
 exemplar_chars {
   base: "A B D {DJ} E F G H I J K L {LH} M N Ñ {NH} O P R S T {TX} U V X Y Z a b d {dj} e f g h i j k l {lh} m n ñ {nh} o p r s t {tx} u v x y z"
-  auxiliary: "Á À Ă Â Å Ä Ã Ā Æ C Ç É È Ĕ Ê Ë Ẽ Ē Í Ì Ĭ Î Ï Ĩ Ī {N̈} Ó Ò Ŏ Ô Ö Õ Ø Ō Œ Q {RR} Ú Ù Ŭ Û Ü Ũ Ū W Ÿ ª á à ă â å ä ã ā æ c ç é è ĕ ê ë ẽ ē í ì ĭ î ï ĩ ī {n̈} º ó ò ŏ ô ö õ ø ō œ q {rr} ú ù ŭ û ü ũ ū w ÿ"
+  auxiliary: "Á À Â Ã C Ç É È Ê Í Ì Î {N̈} Ó Ò Ô Õ Q {RR} Ú Ù Û W ª á à â ã c ç é è ê í ì î {n̈} º ó ò ô q {rr} ú ù û w"
   marks: "◌̀ ◌́ ◌̂ ◌̃ ◌̈ ◌̧"
   numerals: "- , % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – — , ; : ! ? . … \' ‘ ’ \" “ ” « » ( ) [ ] @ * / & # "

--- a/Lib/gflanguages/data/languages/ksp_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ksp_Latn.textproto
@@ -7,5 +7,5 @@ region: "CF"
 region: "TD"
 exemplar_chars {
   base: "a A b B d D e E g G h H i I j J k K l L m M n N o O p P r R s S t T u U v V w W y Y ɔ Ɔ"
-  marks: "◌̍ ◌̠ ◌̂"
+  marks: "◌̍ ◌̱ ◌̂"
 }

--- a/Lib/gflanguages/data/languages/mda_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mda_Latn.textproto
@@ -6,6 +6,6 @@ population: 100000
 region: "NG"
 exemplar_chars {
   base: "a A à À ā Ā â Â ă Ă b B c C d D e E é É ē Ē è È ê Ê ĕ Ĕ ə Ə ɛ Ɛ f F g G h H i I ī Ī ì Ì î Î ĭ Ĭ j J k K l L m M n N o O ō Ō ò Ò ô Ô ŏ Ŏ ɔ Ɔ p P r R s S t T u U ū Ū ù Ù û Û ŭ Ŭ v V w W y Y z Z"
-  marks: "◌̀ ◌̄ ◌̂ ◌̆ ◌́"
+    marks: "◌̀ ◌̄ ◌̂ ◌̌ ◌́"
   auxiliary: "q Q x X"
 }

--- a/Lib/gflanguages/data/languages/mor_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mor_Latn.textproto
@@ -3,6 +3,7 @@ language: "mor"
 script: "Latn"
 name: "Moro"
 region: "SS"
+population: 86000
 exemplar_chars {
   base: "a A b B c C d D ḏ Ḏ đ Đ ꟈ Ꟈ e E ë Ë ə Ə f F g G i I j J k K l L m M n N ñ Ñ ŋ Ŋ o O p P r R ɽ Ɽ s S t T ṯ Ṯ u U w W y Y"
   auxiliary: "h H q Q v V x X z Z"

--- a/Lib/gflanguages/data/languages/mur_Latn.textproto
+++ b/Lib/gflanguages/data/languages/mur_Latn.textproto
@@ -7,6 +7,6 @@ region: "ET"
 region: "SS"
 exemplar_chars {
   base: "a A b B c C d D e E ɛ Ɛ g G i I j J k K l L m M n N ŋ Ŋ o O ɔ Ɔ p P r R t T u U v V w W y Y z Z"
-  marks: "◌̠"
+  marks: "◌̱"
   auxiliary: "f F h H q Q s S x X"
 }

--- a/Lib/gflanguages/data/languages/pnz_Latn.textproto
+++ b/Lib/gflanguages/data/languages/pnz_Latn.textproto
@@ -1,0 +1,14 @@
+id: "pnz_Latn"
+language: "pnz"
+script: "Latn"
+name: "Pana (Central African Republic)"
+population: 153000
+region: "CF"
+region: "CM"
+region: "TD"
+exemplar_chars {
+  base: "a A á Á â Â {a̧} {A̧} {á̧} {Á̧} {â̧} {Â̧} b B ɓ Ɓ d D ɗ Ɗ e E é É ê Ê ȩ Ȩ {ȩ́} {Ȩ́} {ȩ̂} {Ȩ̂} ɛ Ɛ {ɛ́} {Ɛ́} {ɛ̂} {Ɛ̂} {ɛ̧} {Ɛ̧} {ɛ̧́} {Ɛ̧́} {ɛ̧̂} {Ɛ̧̂} f F g G {gb} {GB} h H i I í Í î Î {i̧} {I̧} {í̧} {Í̧} {î̧} {Î̧} k K {kp} {KP} l L m M n N {ny} {NY} ŋ Ŋ o O ó Ó ô Ô {o̧} {O̧} {ó̧} {Ó̧} {ô̧} {Ô̧} ɔ Ɔ {ɔ́} {Ɔ́} {ɔ̂} {Ɔ̂} {ɔ̧} {Ɔ̧} {ɔ̧́} {Ɔ̧́} {ɔ̧̂} {Ɔ̧̂} p P r R s S t T {ts} {TS} u U ú Ú û Û {u̧} {U̧} {ú̧} {Ú̧} {û̧} {Û̧} v V {vb} {VB} w W y Y z Z"
+  marks: "◌́ ◌̂ ◌̧"
+  auxiliary: "c C j J q Q x X"
+}
+source: "Ibirahim Njoya, Précis d’orthographe pour la langue pana, Yaoundé, Cameroun, Association Camerounaise pour la Traduction de la Bible et l’Alphabétisation, 2010"

--- a/Lib/gflanguages/data/languages/rif_Latn.textproto
+++ b/Lib/gflanguages/data/languages/rif_Latn.textproto
@@ -11,7 +11,7 @@ region: "DE"
 region: "BE"
 exemplar_chars {
     base: "a A b B c C č Č d D ḍ Ḍ e E ɛ Ɛ f F g G ǧ Ǧ ɣ Ɣ h H ḥ Ḥ i I j J k K l L m M n N q Q r R ṛ Ṛ s S ṣ Ṣ t T ṭ Ṭ u U w W x X y Y z Z ẓ Ẓ"
-    auxiliary: "ḏ Ḏ ƹ Ƹ ȓ Ȓ γ Γ"
+    auxiliary: "ḏ Ḏ ƹ Ƹ ȓ Ȓ"
     marks: "◌̑ ◌̣ ◌̱"
 }
-note: "Riffian (Latin) Bible translation and other religious material uses ḏ ƹ ȓ. Some documents use the Greek γ Γ or its capital with ɣ."
+note: "Riffian (Latin) Bible translation and other religious material uses ḏ ƹ ȓ. Some documents use the Greek γ Γ or their shapes for ɣ."

--- a/Lib/gflanguages/data/languages/toq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/toq_Latn.textproto
@@ -6,6 +6,6 @@ population: 320000
 region: "SS"
 exemplar_chars {
   base: "a A b B c C d D e E g G i I j J k K l L m M n N ŋ Ŋ o O p P r R s S t T u U w W y Y"
-  marks: "◌̠"
+  marks: "◌̱"
   auxiliary: "f F h H q Q v V x X z Z"
 }

--- a/Lib/gflanguages/data/languages/zu_Latn.textproto
+++ b/Lib/gflanguages/data/languages/zu_Latn.textproto
@@ -11,7 +11,6 @@ region: "SZ"
 region: "ZA"
 exemplar_chars {
   base: "A B {BH} C {CH} D {DL} {DY} E F G {GC} {GQ} {GX} H {HH} {HL} I J K {KH} {KL} {KP} L M N {NC} {NGC} {NGQ} {NGX} {NHL} {NK} {NKC} {NKQ} {NKX} {NQ} {NTSH} {NX} {NY} O P {PH} Q {QH} R {RH} S {SH} T {TH} {TL} {TS} {TSH} U V W X {XH} Y Z a b {bh} c {ch} d {dl} {dy} e f g {gc} {gq} {gx} h {hh} {hl} i j k {kh} {kl} {kp} l m n {nc} {ngc} {ngq} {ngx} {nhl} {nk} {nkc} {nkq} {nkx} {nq} {ntsh} {nx} {ny} o p {ph} q {qh} r {rh} s {sh} t {th} {tl} {ts} {tsh} u v w x {xh} y z"
-  auxiliary: "Á À Ă Â Å Ä Ã Ā Æ Ç É È Ĕ Ê Ë Ē Í Ì Ĭ Î Ï Ī Ñ Ó Ò Ŏ Ô Ö Ø Ō Œ Ú Ù Ŭ Û Ü Ū Ÿ á à ă â å ä ã ā æ ç é è ĕ ê ë ē í ì ĭ î ï ī ñ ó ò ŏ ô ö ø ō œ ú ù ŭ û ü ū ÿ"
   marks: "◌́ ◌̀ ◌̆ ◌̂ ◌̊ ◌̈ ◌̃ ◌̄ ◌̧"
   numerals: "- , . % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- , ; : ! ? . ( ) [ ] { }"


### PR DESCRIPTION
- Update ig_Latn auxiliary with 1936-1961 orthography characters
- kea_Latn, mda_Latin, zu_Latn: remove unvetted copied auxiliary, in particular letter with breve.
- mda_Latn: caron instead of breve for raising tone
- Add har_Latn for its auxiliary
- rif_Latn: remove Greek characters from auxiliary
- Replace combining minus below U+0320 by combining macron below U+0331 in cic_Latn, ema_Latn, ksp_Latn, mor_Latn, mur_Latn, toq_Latn
- Add pnz_Latn, in particular for ȩ and other letters with cedilla.

