### PR TITLE
Update zap_Latn

### DIFF
--- a/Lib/gflanguages/data/languages/zap_Latn.textproto
+++ b/Lib/gflanguages/data/languages/zap_Latn.textproto
@@ -2,9 +2,13 @@ id: "zap_Latn"
 language: "zap"
 script: "Latn"
 name: "Zapotec"
+autonym: "Didxazá"
 population: 490000
 region: "MX"
 exemplar_chars {
-  base: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Á À È É Ë Ì Ü Ñ {S̨} Ž {Z̨} a b c d e f g h i j k l m n o p q r s t u v w x y z á à è é ë ì ü ñ {s̨} ž {z̨}"
-  marks: "◌̀ ◌́ ◌̃ ◌̈ ◌̌ ◌̨"
+  base: "A a B b C c {Ch} {ch} D d {Dx} {dx} {Dz} {dz} E e Ë ë F f G g H h I i Ɨ ɨ J j L l M m N n Ñ ñ O o P p Q q R r {Rr} {rr} S s T t {Th} {th} {Ts} {ts} U u Ü ü W w X x {Xh} {xh} Y y Z z ʰ ’ :"
+  auxiliary : "Á É {Ë́} Í {Ɨ́} Ó Ú Ǘ á é {ë́} í {ɨ́} ó ú ǘ À È {Ë̀} Ì {Ɨ̀} Ò Ù Ǜ à è {ë̀} ì {ɨ̀} ò ù ǜ Â Ê {Ë̂} Î {Ɨ̂} Ô Û {Ü̂} â ê {ë̂} î {ɨ̂} ô û {ü̂} Ǎ Ě {Ë̌} Ǐ {Ɨ̌} Ǒ Ǔ Ǚ ǎ ě {ë̌} ǐ {ɨ̌} ǒ ǔ ǚ"
+  marks: "◌̀ ◌́ ◌̌ ◌̃ ◌̈"
 }
+source: "Oscar Méndez Espinosa, Diccionario del Idioma Zapoteco, vol. 1-4, Universidad del Istmo, 2018"
+note: "There is no clear standard unified orthography for Zapotec languages. Méndez 2018 may be used for the Zapotec group, specific orthographies are or have been used for specific languags. Tones are not always marked and are left in auxiliary."


### PR DESCRIPTION
Could not find a reference using the base exemplar, in particular {s̨} {z̨} stand out.

Now uses Méndez 2018 as a reference for the Zapotac macrolanguage/groupe orthography even if there is no clear standard unified orthography.