### PR TITLE
nb_Latn exemplar chars

### DIFF
--- a/Lib/gflanguages/data/languages/nb_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nb_Latn.textproto
@@ -6,6 +6,14 @@ autonym: "norsk bokmål"
 population: 5468932
 region: "NO"
 region: "SJ"
+exemplar_chars {
+  base: "A B C D E É È Ê F G H I J K L M N O Ó Ò Ô P Q R S T U V W X Y Z Æ Ø Å a à b c d e é è ê f g h i j k l m n o ó ò ô p q r s t u v w x y z æ ø å"
+  auxiliary: "À Á Ǎ Ã Č Ç Đ È Ê Í Ń Ñ Ŋ Š Ŧ Ú Ü Ž Ä Ö á ǎ ã č ç đ è ê í ń ñ ŋ š ŧ ú ü ž ä ö"
+  marks: "◌̀ ◌́ ◌̂ ◌̈ ◌̊"
+  numerals: ", % + − 0 1 2 3 4 5 6 7 8 9"
+  punctuation: "- – , ; : ! ? . \' \" « » ( ) [ ] { } @ * / \\"
+  index: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Æ Ø Å"
+}
 sample_text {
   masthead_full: "AaLl"
   masthead_partial: "Ee"
@@ -20,3 +28,5 @@ sample_text {
   specimen_21: "Intet i denne erklæring skal tolkes slik at det gir noen stat, gruppe eller person rett til å ta del i noen virksomhet eller foreta noen handling som tar sikte på å ødelegge noen av de rettigheter og friheter som er nevnt i Erklæringen.\nDa anerkjennelsen av menneskeverd og like og umistelige rettigheter for alle medlemmer av menneskeslekten er grunnlaget for frihet, rettferdighet og fred i verden,"
   specimen_16: "Da anerkjennelsen av menneskeverd og like og umistelige rettigheter for alle medlemmer av menneskeslekten er grunnlaget for frihet, rettferdighet og fred i verden,\nda tilsidesettelse av og forakt for menneskerettighetene har ført til barbariske handlinger som har rystet menneskehetens samvittighet, og da framveksten av en verden hvor menneskene har tale- og trosfrihet og frihet fra frykt og nød, er blitt kunngjort som folkenes høyeste mål,\nda det er nødvendig at menneskerettighetene blir beskyttet av loven for at menneskene ikke skal tvinges til som siste utvei å gjøre opprør mot tyranni og undertrykkelse,"
 }
+source: "Erik Bolstad, “Norsk alfabet”, Store norske leksikon, 2022, https://snl.no/norsk_alfabet"
+source: "Hanne Gram Simonsen, “Aksenttegn og andre diakritiske tegn”, Store norske leksikon, 2022, https://snl.no/aksenttegn_og_andre_diakritiske_tegn"

--- a/Lib/gflanguages/data/languages/no_Latn.textproto
+++ b/Lib/gflanguages/data/languages/no_Latn.textproto
@@ -6,10 +6,12 @@ autonym: "Norsk"
 population: 4320000
 region: "NO"
 exemplar_chars {
-  base: "A À B C D E É F G H I J K L M N O Ó Ò Ô P Q R S T U V W X Y Z Æ Ø Å a à b c d e é f g h i j k l m n o ó ò ô p q r s t u v w x y z æ ø å"
-  auxiliary: "Á Ǎ Ã Č Ç Đ È Ê Í Ń Ñ Ŋ Š Ŧ Ú Ü Ž Ä Ö á ǎ ã č ç đ è ê í ń ñ ŋ š ŧ ú ü ž ä ö"
+  base: "A B C D E É È Ê F G H I J K L M N O Ó Ò Ô P Q R S T U V W X Y Z Æ Ø Å a à b c d e é è ê f g h i j k l m n o ó ò ô p q r s t u v w x y z æ ø å"
+  auxiliary: "À Á Ǎ Ã Č Ç Đ È Ê Í Ń Ñ Ŋ Š Ŧ Ú Ü Ž Ä Ö á ǎ ã č ç đ è ê í ń ñ ŋ š ŧ ú ü ž ä ö"
   marks: "◌̀ ◌́ ◌̂ ◌̈ ◌̊"
   numerals: ", % + − 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – , ; : ! ? . \' \" « » ( ) [ ] { } @ * / \\"
   index: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z Æ Ø Å"
 }
+source: "Erik Bolstad, “Norsk alfabet”, Store norske leksikon, 2022, https://snl.no/norsk_alfabet"
+source: "Hanne Gram Simonsen, “Aksenttegn og andre diakritiske tegn”, Store norske leksikon, 2022, https://snl.no/aksenttegn_og_andre_diakritiske_tegn"


### PR DESCRIPTION
Shaperglot says "No exemplar glyphs were defined for language Norwegian Bokmål".

nb_Latn: add exemplars, copied from no_Latn and modified

no_Latn: update exemplars