### PR TITLE
Assert uniqueness of all IDs

### DIFF
--- a/Lib/gflanguages/__init__.py
+++ b/Lib/gflanguages/__init__.py
@@ -44,6 +44,7 @@ def LoadLanguages(base_dir=DATA_DIR):
     for textproto_file in glob.iglob(os.path.join(languages_dir, "*.textproto")):
         with open(textproto_file, "r", encoding="utf-8") as f:
             language = text_format.Parse(f.read(), languages_public_pb2.LanguageProto())
+            assert language.id not in langs, f"Duplicate language id: {language.id}"
             langs[language.id] = language
     return langs
 
@@ -57,6 +58,7 @@ def LoadScripts(base_dir=DATA_DIR):
     for textproto_file in glob.iglob(os.path.join(scripts_dir, "*.textproto")):
         with open(textproto_file, "r", encoding="utf-8") as f:
             script = text_format.Parse(f.read(), languages_public_pb2.ScriptProto())
+            assert script.id not in scripts, f"Duplicate script id: {script.id}"
             scripts[script.id] = script
     return scripts
 
@@ -70,6 +72,7 @@ def LoadRegions(base_dir=DATA_DIR):
     for textproto_file in glob.iglob(os.path.join(regions_dir, "*.textproto")):
         with open(textproto_file, "r", encoding="utf-8") as f:
             region = text_format.Parse(f.read(), languages_public_pb2.RegionProto())
+            assert region.id not in regions, f"Duplicate region id: {region.id}"
             regions[region.id] = region
     return regions
 

--- a/Lib/gflanguages/data/languages/mam_Latn_MX.textproto
+++ b/Lib/gflanguages/data/languages/mam_Latn_MX.textproto
@@ -1,7 +1,7 @@
-id: "mam_Latn"
+id: "mam_Latn_MX"
 language: "mam"
 script: "Latn"
-name: "Mam"
+name: "Mexican Mam"
 region: "MX"
 exemplar_chars {
   base: "a A {bꞌ} {BꞋ} {ch} {CH} {chꞌ} {CHꞋ} d D e E g G i I j J k K {kꞌ} {KꞋ} {ky} {KY} {kyꞌ} {KYꞋ} l L m M n N o O p P q Q {qꞌ} {QꞋ} r R s S t T {tꞌ} {TꞋ} {ts} {TS} {tsꞌ} {TSꞋ} {tx} {TX} {txꞌ} {TXꞋ} u U w W x X {xh} {XH} y Y ꞌ Ꞌ"

--- a/Lib/gflanguages/data/languages/xsl_Latn.textproto
+++ b/Lib/gflanguages/data/languages/xsl_Latn.textproto
@@ -1,5 +1,5 @@
-id: "scs_Latn"
-language: "scs"
+id: "xsl_Latn"
+language: "xsl"
 script: "Latn"
 name: "South Slavey"
 population: 950

--- a/Lib/gflanguages/data/languages/yo_Latn_BJ.textproto
+++ b/Lib/gflanguages/data/languages/yo_Latn_BJ.textproto
@@ -1,7 +1,7 @@
-id: "yo_Latn"
+id: "yo_Latn_BJ"
 language: "yo"
 script: "Latn"
-name: "Yoruba"
+name: "Beninese Yoruba"
 autonym: "Èdè Yorùbá"
 population: 200000
 region: "BJ"

--- a/Lib/gflanguages/data/languages/yo_Latn_BJ.textproto
+++ b/Lib/gflanguages/data/languages/yo_Latn_BJ.textproto
@@ -1,7 +1,7 @@
 id: "yo_Latn_BJ"
 language: "yo"
 script: "Latn"
-name: "Beninese Yoruba"
+name: "Yoruba, Benin"
 autonym: "Èdè Yorùbá"
 population: 200000
 region: "BJ"


### PR DESCRIPTION
We noticed that shaperglot was using `yo_Latn_BJ` instead of `yo_Latn`, which was odd. Then we noticed that both languages were called `Yoruba` but this wasn't caught by #154, which was very odd. Then I realised that both textproto files had an `id:` field of `yo_Latn`, so the Beninese Yoruba was overriding the Nigerian Yoruba. Oops.

It turns out we had a few other languages with duplicated IDs too.