### PR TITLE
Make importlib_resources optional

### DIFF
--- a/Lib/gflanguages/__init__.py
+++ b/Lib/gflanguages/__init__.py
@@ -22,10 +22,15 @@ data on the Google Fonts collection.
 import glob
 import os
 import unicodedata
+import sys
 
 from gflanguages import languages_public_pb2
 from google.protobuf import text_format
-from importlib_resources import files
+
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
 try:
     from ._version import version as __version__  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dynamic = ["version"]
 
 name = "gflanguages"
 description = "A python API for evaluating language support in the Google Fonts collection."
+requires-python = ">=3.8"
 readme = "README.md"
 authors = [
    { name = "Simon Cozens", email = "simon@simon-cozens.org" }
@@ -23,7 +24,7 @@ authors = [
 
 dependencies = [
    "protobuf>=3.7.0, <4",
-   "importlib_resources",  # Needed for 3.9 and below
+   "importlib_resources ; python_version < '3.10'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_gflanguages_api.py
+++ b/tests/test_gflanguages_api.py
@@ -14,36 +14,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from pkg_resources import resource_filename
+
+import sys
+
+if sys.version_info < (3, 10):
+    import importlib_resources as importlib_resources
+else:
+    import importlib.resources as importlib_resources
 
 from gflanguages import (LoadLanguages,
                          LoadRegions,
                          LoadScripts)
 
-DATA_DIR = resource_filename("gflanguages", "data")
+DATA_DIR = importlib_resources.files("gflanguages") / "data"
 
 
 def test_LoadLanguages():
-    for langs in [LoadLanguages(),
-                  LoadLanguages(None),
-                  LoadLanguages(DATA_DIR)]:
-        numerals = langs["yi_Hebr"].exemplar_chars.numerals
-        assert numerals == '- , . % + 0 1 2 3 4 5 6 7 8 9'
+    with importlib_resources.as_file(DATA_DIR) as data_path:
+        for langs in [LoadLanguages(),
+                    LoadLanguages(None),
+                    LoadLanguages(data_path)]:
+            numerals = langs["yi_Hebr"].exemplar_chars.numerals
+            assert numerals == '- , . % + 0 1 2 3 4 5 6 7 8 9'
 
 
 def test_LoadScripts():
-    for scripts in [LoadScripts(),
-                    LoadScripts(None),
-                    LoadScripts(DATA_DIR)]:
-        scripts = LoadScripts()
-        assert scripts["Tagb"].name == 'Tagbanwa'
+    with importlib_resources.as_file(DATA_DIR) as data_path:
+        for scripts in [LoadScripts(),
+                        LoadScripts(None),
+                        LoadScripts(data_path)]:
+            scripts = LoadScripts()
+            assert scripts["Tagb"].name == 'Tagbanwa'
 
 
 def test_LoadRegions():
-    for regions in [LoadRegions(),
-                    LoadRegions(None),
-                    LoadRegions(DATA_DIR)]:
-        regions = LoadRegions()
-        br = regions["BR"]
-        assert br.name == 'Brazil'
-        assert br.region_group == ['Americas']
+    with importlib_resources.as_file(DATA_DIR) as data_path:
+        for regions in [LoadRegions(),
+                        LoadRegions(None),
+                        LoadRegions(data_path)]:
+            regions = LoadRegions()
+            br = regions["BR"]
+            assert br.name == 'Brazil'
+            assert br.region_group == ['Americas']

--- a/tests/test_parsable.py
+++ b/tests/test_parsable.py
@@ -1,10 +1,14 @@
-from importlib_resources import files
 import glob
 import os
 import pytest
+import sys
 from gflanguages import languages_public_pb2
 from google.protobuf import text_format
 
+if sys.version_info < (3, 10):
+    from importlib_resources import files
+else:
+    from importlib.resources import files
 
 languages_dir = files("gflanguages.data").joinpath("languages")
 textproto_files = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+env_list = py3{8,9,10,11,12,13}
+minversion = 4.23.2
+
+[testenv]
+description = run the tests with pytest
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=6
+extras = dev
+commands =
+    pytest {tty:--color=yes} {posargs}


### PR DESCRIPTION
In the interest of reducing the number of dependencies, require `importlib_resources` only on Python < 3.10. I think tools like `shed` can automatically delete the if-else checks if the minimum Python version is lifted eventually. `importlib.resources.files` was added in Py 3.9 but testing it there raised some error I didn't feel like investigating, so I gated the dep on 3.10 instead.

Also added a tox config for easy testing. Did you know that you can install tox-uv alongside your tox and uv will automatically download Python versions you don't have? Makes testing across versions very easy. Also, did you know about `tox p`? Makes it time-efficient as well!