### PR TITLE
snk_Latn: ñ, ɲ, and ŋ missing; +regions

### DIFF
--- a/Lib/gflanguages/data/languages/snk_Latn.textproto
+++ b/Lib/gflanguages/data/languages/snk_Latn.textproto
@@ -4,9 +4,12 @@ script: "Latn"
 name: "Soninke"
 autonym: "Sooninkanxanne"
 population: 1153650
+region: "GM"
 region: "ML"
+region: "MR"
+region: "SN"
 exemplar_chars {
-  base: "A B C D E F G H I J K L M N O P Q R S T U W X Y a b c d e f g h i j k l m n o p q r s t u w x y \'"
+  base: "A B C D E F G H I J K L M N Ñ Ŋ Ɲ O P Q R S T U W X Y a b c d e f g h i j k l m n ñ ŋ ɲ o p q r s t u w x y \'"
 }
 sample_text {
   masthead_full: "HhAa"
@@ -22,3 +25,8 @@ sample_text {
   specimen_21: "Killen ma sariyanun saaxaman ga da taqu beenu kini seren ŋa, i ga ñi a mulla i na fo bagu i ya, sere so raawa deemande muurunu kiitiraanu.\nra nta sere su ragana, na texi kaso ma na a bagandi jamaanen ŋa xafu kanma.\nI ga na fo tiifi sere ya, a nan siri i xibaaren dantaqini kiitira be ga nta saafandini, soron su jon ŋa, kiitira ke na a taqun do a waajibinun koyi ma a na ko a ga boxu noqu be."
   specimen_16: "Sere su ra nta roono, fo koono an funen bire moxo, a kore, a kan xibaare ma na a bataaxun xara selli a ga ma an ñamari, a ra nta a roxondini xadi. Sariyan nan siri sere su tangana katta kun baqe, ken xa wa kappa sere su taqu.\nSere su raawa sinmene moxo be gan liŋo an dan ŋa, na ro diina. Ken taqe yan sigi, a ga raawa gilli ke diina katta baane tana. A raawa i diina bagandi sellan ŋa, a baane ma a do soro tanani, ma a kan noxo, a raawa a xaraŋundini, nan bati.\nSere su raawa xibaare walla moxo be gan liŋo a dan ŋa, na kun wariyu bagandi sellan ŋa. Ken wure ni ya sere su raawa wariyu kitta, na a muuru, ma na a sanqi noqu su, moxo su, i ga nta an tanpindini."
 }
+source: "Bandiougou S. Dramé, Marianne Hagg, Guide d’écriture de la langue soninké = Sooninkanxannen safandimoxon geesundidokko, SIL Mali, 2020"
+source: "République du Mali, Direction nationale de l’alphabétisation fonctionnelle et de la linguistique appliquée, Alphabets et règles d'orthographe des langues nationales, Bamako, DNAFLA, 1993"
+source: "République du Sénégal, Décret no 2005-991 relatif à l’orthographe et la séparation des mots en sooninke, 21 octobre 2005"
+source: "République islamique de Mauritanie, “Décret no 81-072 du 15 juillet 1981 fixant les alphabets des langues nationales pulaar, sooninke et wolof en caractères latins”, Journal officiel de la république islamique de Mauritanie, nos 548-549, 26 aout 1981, p. 392–397"
+note: "The ñ is used in Senegal, Gambia and Mauritania; the ɲ is used in Mali."


### PR DESCRIPTION
- Add ŋ (see #200) as well as ñ (used in Senegal, Gambia, Mauritania) and ɲ (used in Mali).
- Add Senegal, Gambia, Mauritania as regions