### PR TITLE
en_Latn: add ʻ U+02BC sometimes used in en-US

### DIFF
--- a/Lib/gflanguages/data/languages/en_Latn.textproto
+++ b/Lib/gflanguages/data/languages/en_Latn.textproto
@@ -154,7 +154,7 @@ region: "ZM"
 region: "ZW"
 exemplar_chars {
   base: "A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z"
-  auxiliary: "Á À Ă Â Å Ä Ã Ā Æ Ç É È Ĕ Ê Ë Ē Í Ì Ĭ Î Ï Ī Ñ Ó Ò Ŏ Ô Ö Ø Ō Œ Ú Ù Ŭ Û Ü Ū Ÿ á à ă â å ä ã ā æ ç é è ĕ ê ë ē í ì ĭ î ï ī ñ ó ò ŏ ô ö ø ō œ ú ù ŭ û ü ū ÿ"
+  auxiliary: "Á À Ă Â Å Ä Ã Ā Æ Ç É È Ĕ Ê Ë Ē Í Ì Ĭ Î Ï Ī Ñ Ó Ò Ŏ Ô Ö Ø Ō Œ Ú Ù Ŭ Û Ü Ū Ÿ á à ă â å ä ã ā æ ç é è ĕ ê ë ē í ì ĭ î ï ī ñ ó ò ŏ ô ö ø ō œ ú ù ŭ û ü ū ÿ ʻ"
   marks: "◌̀ ◌́ ◌̂ ◌̃ ◌̈ ◌̧"
   numerals: "- , . % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – — , ; : ! ? . … \' ‘ ’ \" “ ” ( ) [ ] @ * / & #"


### PR DESCRIPTION
ʻ U+02BC is sometimes used in en-US.
For example:
- https://www.google.com/search?q="Auliʻi"+site:latimes.com
- https://www.google.com/search?q="Hawaiʻi"+site:latimes.com
- https://www.google.com/search?q="Auliʻi"+site:nytimes.com
- https://www.google.com/search?q="Hawaiʻi"+site:nytimes.com
- https://www.google.com/search?q="Auliʻi"+site:washingtonpost.com
- https://www.google.com/search?q="Hawaiʻi"+site:washingtonpost.com
- https://www.google.com/search?q="Hawaiʻi"+site:nps.gov
- https://www.google.com/search?q="Hawaiʻi"+site:whitehouse.gov

It is in 8 words per million in the 2023 Uni Leipzig English news 1M corpus. Some of the other characters in auxiliary are less frequent.