### PR TITLE
buc_Latn: update based on references

### DIFF
--- a/Lib/gflanguages/data/languages/buc_Latn.textproto
+++ b/Lib/gflanguages/data/languages/buc_Latn.textproto
@@ -3,16 +3,16 @@ language: "buc"
 script: "Latn"
 name: "Bushi"
 autonym: "Shibushi"
-population: 44620
+population: 57762
 region: "YT"
 exemplar_chars {
-  base: "A B D E F G H I K L M N O P R S T U V W X Y Z Ɓ Ɗ {N̈} a b d e f g h i k l m n o p r s t u v w x y z ɓ ɗ {n̈}"
-  auxiliary: "C J Q c j q"
-  marks: "◌̈"
+  base: "A À B Ɓ D Ɗ E È F G H I Ì J K L M N Ŋ O Ò P R S T U Ù V W X Y Z a à b ɓ d ɗ e è f g h i ì j k l m n ŋ o ò p r s t u ù v w x y z"
+  auxiliary: "C c Ƀ ƀ Đ đ Ĵ ĵ {N̂} {n̂} {N̈} {n̈} Ô ô Q q Ŝ ŝ Ẑ ẑ"
+  marks: "◌̀ ◌̂ ◌̃ ◌̈"
 }
 sample_text {
   masthead_full: "ƁɓIi"
-  masthead_partial: "Nn"
+  masthead_partial: "Ŋŋ"
   styles: "An-fahitaŋa amba, fikuɓaliaŋa amba ɓinadamu"
   tester: "An-fahitaŋa amba, tsifahizaŋa ndreka fipuzisaŋa haki-l-adamì ro mikutsonga"
   poster_sm: "An-An- fahitaŋa"
@@ -24,3 +24,8 @@ sample_text {
   specimen_21: "Kula huluŋu misi haki an-faŋanovaŋa modeli atà utrilivu amin’ni maisha ki ɓinadamu ndreka amin’ni ulemengu ikuɓala atà haki ndreka unafasi nikudukuruŋu aŋatim- Matekelezo itì, ikurumianaŋa namuna nin-kulazimu.\nTsisi atà sharia areki nim-Matekelezo itì mbu heti kutafaswirinyi amin’ni lalaŋa mikuruhusu, Daula, shikao au huluŋu areki, ihisi haki itsokao yotsi nin-faŋanovaŋa mahafala au ãmali mandrubaka haki ndreka unafasi nikudukuruŋu etu."
   specimen_16: "An-fahitaŋa amba, fikuɓaliaŋa amba ɓinadamu djabi nitirahinyi ndreka usheu ndreka haki meraŋa nandzari ro musingi nin-nafasi, nin-haki ndreka usalama duniani ;\nAn-fahitaŋa amba, tsifahizaŋa ndreka fipuzisaŋa haki-l-adamì ro mikutsonga faŋanovaŋa shitrendro ki katili maneitri rohu nin-umati djabi, amin’ni zenyi, fitunga nin-ulemengu mbu kuruhusu ɓinadamu ivulaŋa ndreka ikwamini aminnafasi, ɓilà tahutru wala taãɓu nin-ufukara, ro nikutekelezaŋa kirasimi, ustaãraɓu beheben-djabi ninhulumbelu ;\nAn- fahitaŋa amba, Daula Aŋatin-shama itì ndreka shama nin-Uvumoja nin-Twaifa (Shama nin-Daula nin-Ulemengu) nangala wahadi an-ndreu aŋaraka kaɓaru retu atà haki-ladamì ndreka nafasi musingi ikustehinyi nankitinyi amin’ni dunia mafia ;"
 }
+source: "Département de Mayotte, Alphabets des langues mahoraises, 2020"
+source: "Département de Mayotte, Recueil des actes administratifs, 20 avril 2020"
+source: "N. J. Gueunier, Dictionnaire du dialecte malgache de Mayotte (Comores), Moroni: KomEDIT, 2016"
+source: "R. Janet, Dictionnaire Kibushi, Webonary.org, 2020"
+note: "Gueunier 2016 proposes and uses ƀ (with a middle stroke), đ (with a middle stroke, or ꟈ) and uses ĵ, n̂, n̈, ô, ŝ, ẑ as linguists from the Malagasy department of the Université d‘Antananarivo. Gueunier 2016 also uses tilde for nasalisation of vowels. In 2020, the Département de Mayotte adopted a different alphabet consistent with the Shimaore alphabet, using ɓ, ɗ, ŋ (or gn), several digraphs, tilde accent for nasalisation of vowels, and with o, u instead of ô, u. The grave accent is typically used for indicating stress when irregular and necessary for disambiguation, like in Malagasy, but it’s not clear if it is combined with other diacritics in practice."


### PR DESCRIPTION
- ŋ was missing from the examplar but is used in the sample text.
- the government 2020 orthography uses grave accent, tilde accent.
- add or move typewriter accessible letters to auxiliary as they are legacy or not in government’s orthography.