### PR TITLE
nl_Latn: add ì ò to auxiliary

### DIFF
--- a/Lib/gflanguages/data/languages/nl_Latn.textproto
+++ b/Lib/gflanguages/data/languages/nl_Latn.textproto
@@ -15,7 +15,7 @@ region: "SR"
 region: "SX"
 exemplar_chars {
   base: "A Á Ä B C D E É Ë F G H I Í Ï {IJ} {ÍJ} {ÍJ́} J K L M N O Ó Ö P Q R S T U Ú Ü V W X Y Ý Z a á ä b c d e é ë f g h i í ï {ij} {íj} {íj́} j k l m n o ó ö p q r s t u ú ü v w x y ý z"
-  auxiliary: "À Â Å Ã Æ Ç È Ê Î Ĳ Ñ Ô Ø Œ Ù Û Ÿ à â å ã æ ç è ê î ĳ ñ ô ø œ ù û ÿ"
+  auxiliary: "À Â Å Ã Æ Ç È Ê Ì Î Ĳ Ñ Ò Ô Ø Œ Ù Û Ÿ à â å ã æ ç è ê ì î ĳ ñ ò ô ø œ ù û ÿ"
   marks: "◌̀ ◌́ ◌̂ ◌̈"
   numerals: "- , . % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – — , ; : ! ? . … \' ‘ ’ \" “ ” ( ) [ ] @ * / & #"


### PR DESCRIPTION
Grave accent used in pre-1995 spelling that some texts use.