### PR TITLE
Update agq_Latn and lom_Latn based on corpus

### DIFF
--- a/Lib/gflanguages/data/languages/agq_Latn.textproto
+++ b/Lib/gflanguages/data/languages/agq_Latn.textproto
@@ -7,7 +7,7 @@ population: 38843
 region: "CM"
 exemplar_chars {
   base: "a A à À â Â ǎ Ǎ ā Ā b B c C d D e E è È ê Ê ě Ě ē Ē ɛ Ɛ {ɛ̀} {Ɛ̀} {ɛ̂} {Ɛ̂} {ɛ̌} {Ɛ̌} {ɛ̄} {Ɛ̄} f F g G h H i I ì Ì î Î ǐ Ǐ ī Ī ɨ Ɨ {ɨ̀} {Ɨ̀} {ɨ̂} {Ɨ̂} {ɨ̌} {Ɨ̌} {ɨ̄} {Ɨ̄} k K l L m M n N ŋ Ŋ o O ò Ò ô Ô ǒ Ǒ ō Ō ɔ Ɔ {ɔ̀} {Ɔ̀} {ɔ̂} {Ɔ̂} {ɔ̌} {Ɔ̌} {ɔ̄} {Ɔ̄} p P s S t T u U ù Ù û Û ǔ Ǔ ū Ū ʉ Ʉ {ʉ̀} {Ʉ̀} {ʉ̂} {Ʉ̂} {ʉ̌} {Ʉ̌} {ʉ̄} {Ʉ̄} v V w W y Y z Z ʼ"
-  auxiliary: "q Q r R x X ’"
+  auxiliary: "q Q r R x X ẁ Ẁ ’"
   marks: "◌̀ ◌̂ ◌̄ ◌̌"
   numerals: "- , % + 0 1 2 3 4 5 6 7 8 9"
   index: "A B C D E Ɛ F G H I Ɨ K L M N Ŋ O Ɔ P S T U Ʉ V W Y Z ʼ"
@@ -28,3 +28,5 @@ sample_text {
 }
 source: "Aghem alphabet, Aghem Language Development Committee “ALDEC” Wum, North West Province Republic of Cameroon, 2010"
 source: "Robyn Hackett, Once upon a Time: A Collection of Five Aghem Folktales, SIL, 2013"
+source: "To kə Kəzə̀ kə̀ Fughu ko, Cameroon Association for Bible Translation and Literacy (CABTAL), 2020"
+note: "ẁ is used in “nduẁ” in CABTAL 2020 but doesn’t seem to be used elsewhere."

--- a/Lib/gflanguages/data/languages/lom_Latn.textproto
+++ b/Lib/gflanguages/data/languages/lom_Latn.textproto
@@ -6,9 +6,10 @@ population: 320000
 region: "LR"
 exemplar_chars {
   base: "a A à À á Á ã Ã {ã̀} {Ã̀} b B ɓ Ɓ d D e E è È é É ê Ê ẽ Ẽ ɛ Ɛ {ɛ̀} {Ɛ̀} {ɛ́} {Ɛ́} {ɛ̃} {Ɛ̃} {ɛ̃̀} {Ɛ̃̀} {ɛ̃́} {Ɛ̃́} f F g G ɣ Ɣ i I ì Ì í Í ĩ Ĩ j J k K l L m M n N ŋ Ŋ o O ò Ò ó Ó õ Õ {õ̀} {Õ̀} ɔ Ɔ {ɔ̀} {Ɔ̀} {ɔ́} {Ɔ́} {ɔ̃} {Ɔ̃} p P s S t T u U ù Ù ú Ú ũ Ũ {ũ̀} {Ũ̀} ṹ Ṹ v V ʋ Ʋ w W y Y z Z"
-  auxiliary: "c C h H q Q r R x X ƃ Ƃ"
+  auxiliary: "c C h H q Q r R x X ƃ Ƃ ẁ Ẁ"
 }
-source: "Deʋe Niinɛi = Loma New Testament, Monrovia: Bible Society of Liberia & British and Foreign Bible Society, 1971"
+source: "Deʋe Niinɛi = Loma New Testament, Monrovia: Bible Society of Liberia & British and Foreign Bible Society (BSL & BFBS), 1971"
 source: "David J. Dwyer, Pewu B. Bodegie & James D. Bague, A learner directed approach to Lorma, United States Peace Corps, 1981"
+source: "Lɔɔma dɔwɔ wɔlɔi = Loma Weekly, 1961"
 source: "Wesley Sadler & Valentin Vydrine, “A complete analysis of the Lɔɔma language (Interior Liberia, West Africa)”, Mandenkan, no. 42, 2006, pp. 5-109"
-note: "The digital version of Deʋe Niinɛi 1971 uses ƃ Ƃ for ɓ Ɓ as its capital looks like Ƃ. Dwyer et al. 1981 uses a phonemic orthography with additional letters like β (or ꞵ), ɗ. Sadler & Vydrine 2006 uses ß instead of ʋ as the original Sadler 1946 or 1949 manuscript used ʋ for a consonsant and ʊ for a vowel."
+note: "The digital version of Deʋe Niinɛi, BSL & BFBS, 1971 uses ƃ Ƃ for ɓ Ɓ as its capital looks like Ƃ. BSL & BFBS also has ẁ in some words but only before vowels with tilde “ẁõila”, “ẁũ”, “ẁõi”, “kẁɛ̃ni”, etc.; JW.org does not use and Lɔɔma dɔwɔ wɔlɔi doesn’t seem to have used ẁ in those words. Dwyer et al. 1981 uses a phonemic orthography with additional letters like β (or ꞵ), ɗ. Sadler & Vydrine 2006 uses ß instead of ʋ as the original Sadler 1946 or 1949 manuscript used ʋ for a consonsant and ʊ for a vowel."


### PR DESCRIPTION
- ẁ is used in both Aghem and Loma Bible translations. Adding it to auxiliary as it seems odd in both cases.