### PR TITLE
Actually this is 0.7.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "google-fonts-languages"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Google Fonts script and language support data"
 repository = "https://github.com/googlefonts/lang"


### PR DESCRIPTION
A tag was pushed for 0.7.5 already but the Rust crate wasn't bumped or released. Let's jump to 0.7.6. Should be fixed from now on, as Rust releases should be automated (and tags are checked against Cargo.toml versions).