### PR TITLE
ee_Latn: remove breve and ring from marks

### DIFF
--- a/Lib/gflanguages/data/languages/ee_Latn.textproto
+++ b/Lib/gflanguages/data/languages/ee_Latn.textproto
@@ -9,7 +9,7 @@ region: "TG"
 exemplar_chars {
   base: "a A á Á à À ã Ã b B d D ɖ Ɖ e E é É è È ẽ Ẽ ɛ Ɛ {ɛ́} {Ɛ́} {ɛ̀} {Ɛ̀} {ɛ̃} {Ɛ̃} f F ƒ Ƒ g G ɣ Ɣ h H x X i I í Í ì Ì ĩ Ĩ k K l L m M n N ŋ Ŋ o O ó Ó ò Ò õ Õ ɔ Ɔ {ɔ́} {Ɔ́} {ɔ̀} {Ɔ̀} {ɔ̃} {Ɔ̃} p P r R s S t T u U ú Ú ù Ù ũ Ũ v V ʋ Ʋ w W y Y z Z"
   auxiliary: "â Â æ Æ c C ç Ç ê Ê ë Ë î Î ï Ï j J ô Ô œ Œ q Q û Û ü Ü"
-  marks: "◌̀ ◌́ ◌̃ ◌̂ ◌̄ ◌̆ ◌̈ ◌̊ ◌̧"
+  marks: "◌̀ ◌́ ◌̃ ◌̂ ◌̄ ◌̈ ◌̧"
   numerals: "- , . % + 0 1 2 3 4 5 6 7 8 9"
   punctuation: "- – — , ; : ! ? . … \' ‘ ’ \" “ ” ( ) [ ] { } @ * / & #"
   index: "A B D Ɖ E Ɛ F Ƒ G Ɣ H X I K L M N Ŋ O Ɔ P R S T U V Ʋ W Y Z"


### PR DESCRIPTION
These are not used in languages that may have names borrowed, and were’t used in old orthography (not covered anyway).